### PR TITLE
space in function parameter name "number 2"

### DIFF
--- a/docs/pycom_esp32/getstarted.rst
+++ b/docs/pycom_esp32/getstarted.rst
@@ -273,7 +273,7 @@ Functions are blocks of code that are referred to by name. Data can be passed in
 
 The function below takes two numbers and adds them together, outputting the result. ::
 
-	def add(number1, number 2):
+	def add(number1, number2):
 	    return number1 + number2
 
 	add(1,2) # expect a result of 3


### PR DESCRIPTION
trivial correct of parameter name 
from "number 2" to "number2"