### PR TITLE
mpconfigport.h: Enable running pre-compiled scripts from the file system

### DIFF
--- a/esp32/mpconfigport.h
+++ b/esp32/mpconfigport.h
@@ -42,6 +42,7 @@
 #include <stdint.h>
 
 // options to control how Micro Python is built
+#define MICROPY_PERSISTENT_CODE_LOAD        (1)
 #define MICROPY_OBJ_REPR                            (MICROPY_OBJ_REPR_A)
 #define MICROPY_ALLOC_PATH_MAX                      (128)
 #define MICROPY_EMIT_X64                            (0)


### PR DESCRIPTION
This feature is supported in the code, but not enabled yet. Enabling it
allows to run code pre-compiled with mpy-cross without the need to embed it
into the formware as frozen bytecode. Running bytecode from the file system
saves the compiling phase, allowing larger scripts and giving faster load time.