### PR TITLE
 ESP32: Enable method micropython.kbd_intr()

### DIFF
--- a/esp32/mods/pybdac.c
+++ b/esp32/mods/pybdac.c
@@ -176,9 +176,15 @@ STATIC mp_obj_t dac_tone(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
         tone+=125;
         pyb_dac_obj[0].tone_step = (tone *(1<<16)) / 8000000 - 1;
 
-    }
-    else {
+    } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "DAC tone frequency out of range"));
+    }
+    uint16_t tone_scale =  args[1].u_int;
+    if (tone_scale >= 0 && tone_scale <= 3) {
+        self->tone_scale = tone_scale;
+
+    } else {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "DAC tone scale out of range"));
     }
     self->tone = true;
     self->dc_value = 0;

--- a/esp32/mpconfigport.h
+++ b/esp32/mpconfigport.h
@@ -42,6 +42,7 @@
 #include <stdint.h>
 
 // options to control how Micro Python is built
+#define MICROPY_PERSISTENT_CODE_LOAD        (1)
 #define MICROPY_OBJ_REPR                            (MICROPY_OBJ_REPR_A)
 #define MICROPY_ALLOC_PATH_MAX                      (128)
 #define MICROPY_EMIT_X64                            (0)

--- a/esp32/mpconfigport.h
+++ b/esp32/mpconfigport.h
@@ -42,7 +42,7 @@
 #include <stdint.h>
 
 // options to control how Micro Python is built
-#define MICROPY_PERSISTENT_CODE_LOAD        (1)
+#define MICROPY_PERSISTENT_CODE_LOAD                (1)
 #define MICROPY_OBJ_REPR                            (MICROPY_OBJ_REPR_A)
 #define MICROPY_ALLOC_PATH_MAX                      (128)
 #define MICROPY_EMIT_X64                            (0)
@@ -116,6 +116,7 @@
 
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF      (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE        (0)
+#define MICROPY_KBD_EXCEPTION                       (1)
 
 #ifndef BOOTLOADER_BUILD
 #include "freertos/FreeRTOS.h"

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -30,6 +30,7 @@
 #include "py/builtin.h"
 #include "py/stackctrl.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 
 // Various builtins specific to MicroPython runtime,
 // living in micropython module
@@ -128,6 +129,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_unlock_obj, mp_micropython_
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_alloc_emergency_exception_buf_obj, mp_alloc_emergency_exception_buf);
 #endif
 
+#if MICROPY_KBD_EXCEPTION
+STATIC mp_obj_t mp_micropython_kbd_intr(mp_obj_t int_chr_in) {
+    mp_hal_set_interrupt_char(mp_obj_get_int(int_chr_in));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd_intr);
+#endif
+
 STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_micropython) },
     { MP_ROM_QSTR(MP_QSTR_const), MP_ROM_PTR(&mp_identity_obj) },
@@ -147,6 +156,9 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
 #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF && (MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE == 0)
     { MP_ROM_QSTR(MP_QSTR_alloc_emergency_exception_buf), MP_ROM_PTR(&mp_alloc_emergency_exception_buf_obj) },
 #endif
+    #if MICROPY_KBD_EXCEPTION
+    { MP_ROM_QSTR(MP_QSTR_kbd_intr), MP_ROM_PTR(&mp_micropython_kbd_intr_obj) },
+    #endif
     #if MICROPY_ENABLE_GC
     { MP_ROM_QSTR(MP_QSTR_heap_lock), MP_ROM_PTR(&mp_micropython_heap_lock_obj) },
     { MP_ROM_QSTR(MP_QSTR_heap_unlock), MP_ROM_PTR(&mp_micropython_heap_unlock_obj) },


### PR DESCRIPTION
This method allows setting the keyboard interrupt character.
micropython.kbd_intr(-1) disables keyboard interrupts, while
micropython.kbd_intr(3) sets it back to Ctrl-C