### PR TITLE
esp32: Add code for the second parameter of DAC.tone()

### DIFF
--- a/esp32/mods/pybdac.c
+++ b/esp32/mods/pybdac.c
@@ -176,9 +176,15 @@ STATIC mp_obj_t dac_tone(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
         tone+=125;
         pyb_dac_obj[0].tone_step = (tone *(1<<16)) / 8000000 - 1;
 
-    }
-    else {
+    } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "DAC tone frequency out of range"));
+    }
+    uint16_t tone_scale =  args[1].u_int;
+    if (tone_scale >= 0 && tone_scale <= 3) {
+        self->tone_scale = tone_scale;
+
+    } else {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "DAC tone scale out of range"));
     }
     self->tone = true;
     self->dc_value = 0;


### PR DESCRIPTION
This parameter specifies the level, which is already documented, but was
not implemented. Suitable values:
0: Tone level 3.02 Vpp at 560 Ohm load, about 0 dbV
1: Tone level 1.54 Vpp, about -6 dBV
2: Tone level 0.8 Vpp, about -12 dBV
3: Tone level 0.4 Vpp, about -18 dBV

Adding a small load is reccomended, since that also suppresses
DAC reloading spikes.