### PR TITLE
New IDF needs a new toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,15 @@ the Espressif website:
 
 - for 64-bit Linux::
 
-    https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-59.tar.gz
+    https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz
 
 - for 32-bit Linux::
 
-    https://dl.espressif.com/dl/xtensa-esp32-elf-linux32-1.22.0-59.tar.gz
+    https://dl.espressif.com/dl/xtensa-esp32-elf-linux32-1.22.0-61-gab8375a-5.2.0.tar.gz
 
 - for Mac OS:
 
-    https://dl.espressif.com/dl/xtensa-esp32-elf-osx-1.22.0-59.tar.gz
+    https://dl.espressif.com/dl/xtensa-esp32-elf-osx-1.22.0-61-gab8375a-5.2.0.tar.gz
 
 To use it, you will need to update your ``PATH`` environment variable in ``~/.bash_profile`` file. To make ``xtensa-esp32-elf`` available for all terminal sessions, add the following line to your ``~/.bash_profile`` file::
 


### PR DESCRIPTION
Update documentation to use the new .61 build of the xtensa toolchain