### PR TITLE
Fixes an SSL / TLS socket blocking problem

### DIFF
--- a/esp32/mods/modwlan.c
+++ b/esp32/mods/modwlan.c
@@ -1373,8 +1373,16 @@ static int wlan_socket_recv(mod_network_socket_obj_t *s, byte *buf, mp_uint_t le
         mp_obj_ssl_socket_t *ss = (mp_obj_ssl_socket_t *)s;
         do {
             ret = mbedtls_ssl_read(&ss->ssl, (unsigned char *)buf, len);
-            if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE || ret == MBEDTLS_ERR_SSL_TIMEOUT) {
+            if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
                 // do nothing
+            } else if(ret == MBEDTLS_ERR_SSL_TIMEOUT){
+                // printf("SSL timeout recieved\n");
+                // non-blocking return
+                if(s->sock_base.timeout == 0){
+                    ret = 0;
+                    break;
+                }
+                // blocking do nothing
             } else if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
                 // printf("Close notify received\n");
                 ret = 0;


### PR DESCRIPTION
I don't know why the "MBEDTLS_ERR_SSL_TIMEOUT" is thrown after a connection has succeeded.  However, the "do nothing" loop in combination with this error in "wlan_socket_recv" was causing the socket to block even when the timeout was set to 0.  Catching this error and returning zero bytes on a non-blocking ssl socket seems to work.  I tested this quickly with a self signed cert on a node.js server...

If this seems too "hacky" then mbedtls needs debugged and modified appropriately.  The mbedtls code is wrapped up in a library at the moment so the source is not readily available in the tree...