### PR TITLE
Added hostname configuration to WLAN module

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -61,8 +61,6 @@ CFLAGS = $(CFLAGS_XTENSA) $(CFLAGS_XTENSA_OPT) -nostdlib -std=gnu99 -g3 -ggdb -f
 LDFLAGS = -nostdlib -Wl,-Map=$(@:.elf=.map) -Wl,--no-check-sections -u call_user_start_cpu0
 LDFLAGS += -Wl,-static -Wl,--undefined=uxTopUsedPriority -Wl,--gc-sections
 
-INC=$(ESP_IDF_PATH)/components/esp32/include
-
 LIBS = -L$(ESP_IDF_COMP_PATH)/esp32/lib -L$(ESP_IDF_COMP_PATH)/esp32/ld -L$(ESP_IDF_COMP_PATH)/bt/lib \
        -L$(ESP_IDF_COMP_PATH)/esp32 -L$(ESP_IDF_COMP_PATH)/newlib/lib -Lbootloader \
        -Llib -lnvs_flash -ltcpip_adapter -L$(BUILD) -lhal -lcore -lwps -lcoexist \

--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -61,6 +61,8 @@ CFLAGS = $(CFLAGS_XTENSA) $(CFLAGS_XTENSA_OPT) -nostdlib -std=gnu99 -g3 -ggdb -f
 LDFLAGS = -nostdlib -Wl,-Map=$(@:.elf=.map) -Wl,--no-check-sections -u call_user_start_cpu0
 LDFLAGS += -Wl,-static -Wl,--undefined=uxTopUsedPriority -Wl,--gc-sections
 
+INC=$(ESP_IDF_PATH)/components/esp32/include
+
 LIBS = -L$(ESP_IDF_COMP_PATH)/esp32/lib -L$(ESP_IDF_COMP_PATH)/esp32/ld -L$(ESP_IDF_COMP_PATH)/bt/lib \
        -L$(ESP_IDF_COMP_PATH)/esp32 -L$(ESP_IDF_COMP_PATH)/newlib/lib -Lbootloader \
        -Llib -lnvs_flash -ltcpip_adapter -L$(BUILD) -lhal -lcore -lwps -lcoexist \

--- a/esp32/mods/modwlan.c
+++ b/esp32/mods/modwlan.c
@@ -202,7 +202,7 @@ void wlan_pre_init (void) {
     wlan_obj.base.type = (mp_obj_t)&mod_network_nic_type_wlan;
 }
 
-void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac) {
+void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, char *hostname) {
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));

--- a/esp32/mods/modwlan.c
+++ b/esp32/mods/modwlan.c
@@ -673,8 +673,8 @@ STATIC mp_obj_t wlan_init_helper(wlan_obj_t *self, const mp_arg_val_t *args) {
 
     // get the hostname
     const char *hostname = NULL;
-    if (args[7].u_obj != NULL) {
-        hostname = mp_obj_str_get_str(args[7].u_obj);
+    if (args[6].u_obj != NULL) {
+        hostname = mp_obj_str_get_str(args[6].u_obj);
         wlan_validate_hostname_len(strlen(hostname));
     }
 

--- a/esp32/mods/modwlan.c
+++ b/esp32/mods/modwlan.c
@@ -203,7 +203,7 @@ void wlan_pre_init (void) {
     wlan_obj.base.type = (mp_obj_t)&mod_network_nic_type_wlan;
 }
 
-void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, char *hostname) {
+void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, const char *hostname) {
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));

--- a/esp32/mods/modwlan.c
+++ b/esp32/mods/modwlan.c
@@ -673,7 +673,7 @@ STATIC mp_obj_t wlan_init_helper(wlan_obj_t *self, const mp_arg_val_t *args) {
     const char *hostname = NULL;
     if (args[7].u_obj != NULL) {
         hostname = mp_obj_str_get_str(args[7].u_obj);
-        wlan_validate_host_len(strlen(hostname));
+        wlan_validate_hostname_len(strlen(hostname));
     }
 
     if (mode != WIFI_MODE_STA) {

--- a/esp32/mods/modwlan.c
+++ b/esp32/mods/modwlan.c
@@ -220,12 +220,14 @@ void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key,
     wlan_set_antenna(antenna);
     wlan_set_mode(mode);
 
+    // Add hostname
+ 
     if (mode != WIFI_MODE_STA) {
         wlan_setup_ap (ssid, auth, key, channel, add_mac);
-        tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, "Dickmunch_STA");
+        tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_AP, hostname);
     }
     else { 
-        tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, "Dickmunch_AP");
+        tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, hostname);
     }
 
     esp_wifi_start();

--- a/esp32/mods/modwlan.c
+++ b/esp32/mods/modwlan.c
@@ -53,6 +53,9 @@
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
 
+#include "tcpip_adapter.h"
+
+
 /******************************************************************************
  DEFINE TYPES
  ******************************************************************************/
@@ -218,6 +221,10 @@ void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key,
 
     if (mode != WIFI_MODE_STA) {
         wlan_setup_ap (ssid, auth, key, channel, add_mac);
+        tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, "Dickmunch_STA");
+    }
+    else { 
+        tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, "Dickmunch_AP");
     }
 
     esp_wifi_start();

--- a/esp32/mods/modwlan.h
+++ b/esp32/mods/modwlan.h
@@ -53,6 +53,7 @@ typedef struct _wlan_obj_t {
     uint8_t                 ssid[(MODWLAN_SSID_LEN_MAX + 1)];
     uint8_t                 key[65];
     uint8_t                 mac[6];
+    uint8_t                 hostname[16];
 
     // the sssid (or name) and mac of the other device
     uint8_t                 ssid_o[33];
@@ -74,7 +75,7 @@ extern wlan_obj_t wlan_obj;
  DECLARE PUBLIC FUNCTIONS
  ******************************************************************************/
 extern void wlan_pre_init (void);
-extern void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac);
+extern void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, char *hostname);
 extern void wlan_update(void);
 extern void wlan_get_mac (uint8_t *macAddress);
 extern void wlan_get_ip (uint32_t *ip);

--- a/esp32/mods/modwlan.h
+++ b/esp32/mods/modwlan.h
@@ -75,7 +75,7 @@ extern wlan_obj_t wlan_obj;
  DECLARE PUBLIC FUNCTIONS
  ******************************************************************************/
 extern void wlan_pre_init (void);
-extern void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, char *hostname);
+extern void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, const char *hostname);
 extern void wlan_update(void);
 extern void wlan_get_mac (uint8_t *macAddress);
 extern void wlan_get_ip (uint32_t *ip);

--- a/esp32/mptask.c
+++ b/esp32/mptask.c
@@ -410,8 +410,7 @@ STATIC void mptask_update_lpwan_mac_address (void) {
 #endif
 
 STATIC void mptask_enable_wifi_ap (void) {
-    wlan_setup (WIFI_MODE_AP, DEFAULT_AP_SSID, WIFI_AUTH_WPA2_PSK, DEFAULT_AP_PASSWORD,
-                DEFAULT_AP_CHANNEL, ANTENNA_TYPE_INTERNAL, true);
+    wlan_setup (WIFI_MODE_AP, DEFAULT_AP_SSID, WIFI_AUTH_WPA2_PSK, DEFAULT_AP_PASSWORD, DEFAULT_AP_CHANNEL, ANTENNA_TYPE_INTERNAL, true, "illysky");
     mod_network_register_nic(&wlan_obj);
 }
 


### PR DESCRIPTION
Added hostname when creating WLAN STA or AP object. Useful for getting the device IP address from router attached devices. Overrides “espressif” hostname.

eg,
from network import WLAN
w = WLAN(mode=WLAN.STA, hostname=“Pycom”) 

I’ve limited the hostname to 16 characters, not sure what the limit should be off top of my head. 

Cheers 