### PR TITLE
sflash_diskio.c: Use spi_flash_get_chip_size() to determine the flash size

### DIFF
--- a/esp32/fatfs/src/drivers/sflash_diskio.c
+++ b/esp32/fatfs/src/drivers/sflash_diskio.c
@@ -12,6 +12,8 @@
 #include "freertos/semphr.h"
 #include "freertos/queue.h"
 
+#include "esp_spi_flash.h"
+
 
 static uint8_t *sflash_block_cache;
 static bool sflash_cache_is_dirty;
@@ -33,7 +35,7 @@ static bool sflash_write (void) {
 
 DRESULT sflash_disk_init (void) {
     if (!sflash_init_done) {
-        if (esp_get_revision() > 0) {
+        if (spi_flash_get_chip_size() > (4 * 1024 * 1024)) {
             sflash_start_address = SFLASH_START_ADDR_8MB;
             sflash_fs_sector_count = SFLASH_FS_SECTOR_COUNT_8MB;
         } else {


### PR DESCRIPTION
This is the direct method of using the flash size as reported by the spi_flash_get_chip_size() call instead of assuming the flash size by the chip revision number.