### PR TITLE
modpycom.c/pulses_get(): prevent lock-up at long pulses

### DIFF
--- a/esp32/mods/modpycom.c
+++ b/esp32/mods/modpycom.c
@@ -110,7 +110,7 @@ STATIC mp_obj_t mod_pycom_pulses_get (mp_obj_t gpio, mp_obj_t timeout) {
     rmt_rx.rmt_mode = RMT_MODE_RX;
     rmt_rx.rx_config.filter_en = true;
     rmt_rx.rx_config.filter_ticks_thresh = 100;
-    rmt_rx.rx_config.idle_threshold = 20000;
+    rmt_rx.rx_config.idle_threshold = 0xffff;
     rmt_config(&rmt_rx);
 
     RingbufHandle_t rb = NULL;


### PR DESCRIPTION
pulses_get() gets into a kind of lock state, if pulses with a duration of > 20000µs are applied and the time out was set to an appropriate large value, like 30000. It does not simply return wrong values, but from one "overflow" event on it returns the value pair 19879, 0 irrespective of the signal applied to the input. Only hard reset fixes that. 
This PR  results in a more robust behavior. For pulses of > 32768µs a wrong value will be reported, but after returning to shorter pulses, these will be reported correctly.