### PR TITLE
Fix modbt scan response adv data length

### DIFF
--- a/esp32/mods/modbt.c
+++ b/esp32/mods/modbt.c
@@ -787,7 +787,7 @@ STATIC mp_obj_t bt_read_scan(mp_obj_t self_in) {
         tuple[1] = mp_obj_new_int(bt_event.scan.scan_rst.ble_addr_type);
         tuple[2] = mp_obj_new_int(bt_event.scan.scan_rst.ble_evt_type & 0x03);    // FIXME
         tuple[3] = mp_obj_new_int(bt_event.scan.scan_rst.rssi);
-        tuple[4] = mp_obj_new_bytes((const byte *)bt_event.scan.scan_rst.ble_adv, ESP_BLE_ADV_DATA_LEN_MAX);
+        tuple[4] = mp_obj_new_bytes((const byte *)bt_event.scan.scan_rst.ble_adv, sizeof(bt_event.scan.scan_rst.ble_adv));
 
         return mp_obj_new_attrtuple(bt_scan_info_fields, 5, tuple);
     }
@@ -809,7 +809,7 @@ STATIC mp_obj_t bt_get_advertisements(mp_obj_t self_in) {
         tuple[1] = mp_obj_new_int(bt_event.scan.scan_rst.ble_addr_type);
         tuple[2] = mp_obj_new_int(bt_event.scan.scan_rst.ble_evt_type & 0x03);    // FIXME
         tuple[3] = mp_obj_new_int(bt_event.scan.scan_rst.rssi);
-        tuple[4] = mp_obj_new_bytes((const byte *)bt_event.scan.scan_rst.ble_adv, ESP_BLE_ADV_DATA_LEN_MAX);
+        tuple[4] = mp_obj_new_bytes((const byte *)bt_event.scan.scan_rst.ble_adv, sizeof(bt_event.scan.scan_rst.ble_adv));
 
         mp_obj_list_append(advs, mp_obj_new_attrtuple(bt_scan_info_fields, 5, tuple));
     }


### PR DESCRIPTION
Although advertising packets are limited to 31 bytes, certain advertising peripherals allow for an additional “scan response” of more data. The ble_adv data bytes should use dynamic sizing via sizeof instead of static ESP_BLE_ADV_DATA_LEN_MAX.

More information is documented at a nearly identical issue: https://github.com/espressif/esp-idf/issues/369

Pycom forum discussion at: https://forum.pycom.io/topic/2460/ble-features-non-blocking-connects-char-presentation-format