### PR TITLE
Endable a debug mode for modlte.c

### DIFF
--- a/esp32/mods/modlte.c
+++ b/esp32/mods/modlte.c
@@ -83,7 +83,7 @@
 
 #define FILE_READ_SIZE 512
 
-#define LTE_DEBUG 1
+#define LTE_DEBUG 0
 
 /******************************************************************************
  DECLARE PRIVATE DATA


### PR DESCRIPTION
There are various useful debug messages that are commented out in modlte.c. I put each of them in a macro block (I think that's what it's called, correct me if I'm wrong) and un-commented. They can now be activated by setting LTE_DEBUG to 1