### PR TITLE
ESP32: Add control for the Ctrl-F hot key

### DIFF
--- a/esp32/fatfs/src/drivers/sflash_diskio.c
+++ b/esp32/fatfs/src/drivers/sflash_diskio.c
@@ -43,7 +43,7 @@ static bool sflash_write (void) {
 DRESULT sflash_disk_init (void) {
     if (!sflash_init_done) {
         // this is how we diferentiate flash sizes in Pycom modules
-        if (esp_get_revision() > 0) {
+        if (spi_flash_get_chip_size() > (4 * 1024 * 1024)) {
             sflash_start_address = SFLASH_START_ADDR_8MB;
             sflash_fs_sector_count = SFLASH_FS_SECTOR_COUNT_8MB;
         } else {

--- a/esp32/hal/esp32_mphal.h
+++ b/esp32/hal/esp32_mphal.h
@@ -27,6 +27,7 @@ uint64_t mp_hal_ticks_ms_non_blocking(void);
 uint64_t mp_hal_ticks_us_non_blocking(void);
 void mp_hal_delay_ms(uint32_t delay);
 void mp_hal_set_interrupt_char(int c);
+void mp_hal_set_reset_char(int c);
 void mp_hal_reset_safe_and_boot(bool reset);
 
 #endif // _INCLUDED_MPHAL_H_

--- a/esp32/main.c
+++ b/esp32/main.c
@@ -123,8 +123,7 @@ void app_main(void) {
     mperror_pre_init();
 
     // differentiate the Flash Size (either 8MB or 4MB) based on ESP32 rev id
-    // micropy_hw_flash_size = (esp_get_revision() > 0 ? 0x800000 : 0x400000);
-    micropy_hw_flash_size = spi_flash_get_chip_size();
+    micropy_hw_flash_size = (spi_flash_get_chip_size() > (4 * 1024 * 1024) ? 0x800000 : 0x400000);
 
     // propagating the Flash Size in the global variable (used in multiple IDF modules)
     g_rom_flashchip.chip_size = micropy_hw_flash_size;

--- a/esp32/main.c
+++ b/esp32/main.c
@@ -52,6 +52,8 @@
 #include "mperror.h"
 #include "machtimer.h"
 
+#include "esp_spi_flash.h"
+
 
 TaskHandle_t mpTaskHandle;
 TaskHandle_t svTaskHandle;
@@ -121,7 +123,8 @@ void app_main(void) {
     mperror_pre_init();
 
     // differentiate the Flash Size (either 8MB or 4MB) based on ESP32 rev id
-    micropy_hw_flash_size = (esp_get_revision() > 0 ? 0x800000 : 0x400000);
+    // micropy_hw_flash_size = (esp_get_revision() > 0 ? 0x800000 : 0x400000);
+    micropy_hw_flash_size = spi_flash_get_chip_size();
 
     // propagating the Flash Size in the global variable (used in multiple IDF modules)
     g_rom_flashchip.chip_size = micropy_hw_flash_size;

--- a/esp32/mods/machuart.c
+++ b/esp32/mods/machuart.c
@@ -302,7 +302,7 @@ STATIC IRAM_ATTR void UARTRxCallback(int uart_id, int rx_byte) {
         if (mp_interrupt_char == rx_byte) {
             // raise an exception when interrupts are finished
             mp_keyboard_interrupt();
-        } else if (CHAR_CTRL_F == rx_byte) {
+        } else if (mp_reset_char == rx_byte) {
             servers_reset_and_safe_boot();
         }
     }

--- a/esp32/telnet/telnet.c
+++ b/esp32/telnet/telnet.c
@@ -537,7 +537,7 @@ static void telnet_parse_input (uint8_t *str, int32_t *len) {
             (ch == mp_interrupt_char || ch == CHAR_CTRL_F))) {
             if (ch == mp_interrupt_char) {
                 mp_keyboard_interrupt();
-            } else if (ch == CHAR_CTRL_F) {
+            } else if (ch == mp_reset_char) {
                 *str++ = CHAR_CTRL_D;
                 mp_hal_reset_safe_and_boot(false);
                 _str++;

--- a/esp32/telnet/telnet.c
+++ b/esp32/telnet/telnet.c
@@ -534,7 +534,7 @@ static void telnet_parse_input (uint8_t *str, int32_t *len) {
 
         // in this case the server is not operating in binary mode
         if (ch > 127 || ch == 0 || (telnet_data.state == E_TELNET_STE_LOGGED_IN &&
-            (ch == mp_interrupt_char || ch == CHAR_CTRL_F))) {
+            (ch == mp_interrupt_char || ch == mp_reset_char))) {
             if (ch == mp_interrupt_char) {
                 mp_keyboard_interrupt();
             } else if (ch == mp_reset_char) {

--- a/lib/utils/interrupt_char.c
+++ b/lib/utils/interrupt_char.c
@@ -28,12 +28,17 @@
 #include "py/mpstate.h"
 
 int mp_interrupt_char;
+int mp_reset_char;
 
 void mp_hal_set_interrupt_char(int c) {
     if (c != -1) {
         mp_obj_exception_clear_traceback(MP_STATE_PORT(mp_kbd_exception));
     }
     mp_interrupt_char = c;
+}
+
+void mp_hal_set_reset_char(int c) {
+    mp_reset_char = c;
 }
 
 void mp_keyboard_interrupt(void) {

--- a/lib/utils/interrupt_char.h
+++ b/lib/utils/interrupt_char.h
@@ -25,5 +25,7 @@
  */
 
 extern int mp_interrupt_char;
+extern int mp_reset_char;
 void mp_hal_set_interrupt_char(int c);
+void mp_hal_set_reset_char(int c);
 void mp_keyboard_interrupt(void);

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -88,6 +88,7 @@ STATIC int parse_compile_execute(void *source, mp_parse_input_kind_t input_kind,
         start = mp_hal_ticks_ms();
         mp_call_function_0(module_fun);
         mp_hal_set_interrupt_char(-1); // disable interrupt
+        mp_hal_set_reset_char(CHAR_CTRL_F); // enable reset char
         nlr_pop();
         ret = 1;
         if (exec_flags & EXEC_FLAG_PRINT_EOF) {
@@ -97,6 +98,7 @@ STATIC int parse_compile_execute(void *source, mp_parse_input_kind_t input_kind,
         // uncaught exception
         // FIXME it could be that an interrupt happens just before we disable it here
         mp_hal_set_interrupt_char(-1); // disable interrupt
+        mp_hal_set_reset_char(CHAR_CTRL_F); // enable reset char, might be wrong here
         // print EOF after normal output
         if (exec_flags & EXEC_FLAG_PRINT_EOF) {
             mp_hal_stdout_tx_strn("\x04", 1);

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -130,11 +130,19 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_alloc_emergency_exception_buf_obj, mp_alloc_
 #endif
 
 #if MICROPY_KBD_EXCEPTION
-STATIC mp_obj_t mp_micropython_kbd_intr(mp_obj_t int_chr_in) {
-    mp_hal_set_interrupt_char(mp_obj_get_int(int_chr_in));
+STATIC mp_obj_t mp_micropython_kbd_intr(size_t n_args, const mp_obj_t *args) {
+    int c = mp_obj_get_int(args[0]);
+    mp_hal_set_interrupt_char(c);
+    if (n_args == 1) {
+        if (c == -1) {
+            mp_hal_set_reset_char(-1);
+        }
+    } else {
+        mp_hal_set_reset_char(mp_obj_get_int(args[1]));
+    }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd_intr);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_micropython_kbd_intr_obj, 1, 2, mp_micropython_kbd_intr);
 #endif
 
 STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {


### PR DESCRIPTION
The activity of the Ctrl-F key can be controlled like the Ctrl-C key
with micropython.kbd_intr().
kbd_intr(-1)
    Disable both Ctrl-C and Ctrl-F. This maintains backward compatibility
    to existing code.
kbd_intr(interrupt-char)
    Set the char for Interrupt by its ordinal value. The default would be 3 (Ctrl-C)
kbd_intr(interrupt-char, reset-char)
    Set the characters for both interrupt and reset. The typical
    values would be 3 (Ctrl-C) and 6 (Ctrl-F)