### PR TITLE
lib/lora: Allow non-zero dr_min for top channels in AU/US915 regions

### DIFF
--- a/lib/lora/mac/region/RegionAU915.c
+++ b/lib/lora/mac/region/RegionAU915.c
@@ -841,11 +841,12 @@ LoRaMacStatus_t RegionAU915ChannelManualAdd( ChannelAddParams_t* channelAdd )
         return LORAMAC_STATUS_PARAMETER_INVALID;
     }
 
-    // Validate the datarate range for min: must be DR_0
-    if( channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
+    // Validate the datarate range for min: must be DR_0 for channels 0-63
+    if( id < 64 && channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
     {
         drInvalid = true;
     }
+
     // Validate the datarate range for max: must be <= TX_MAX_DATARATE
     if( channelAdd->NewChannel->DrRange.Fields.Max > AU915_TX_MAX_DATARATE )
     {

--- a/lib/lora/mac/region/RegionUS915.c
+++ b/lib/lora/mac/region/RegionUS915.c
@@ -849,11 +849,12 @@ LoRaMacStatus_t RegionUS915ChannelManualAdd( ChannelAddParams_t* channelAdd )
         return LORAMAC_STATUS_PARAMETER_INVALID;
     }
 
-    // Validate the datarate range for min: must be DR_0
-    if( channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
+    // Validate the datarate range for min: must be DR_0 for channels 0-63
+    if( id < 64 && channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
     {
         drInvalid = true;
     }
+
     // Validate the datarate range for max: must be <= TX_MAX_DATARATE
     if( channelAdd->NewChannel->DrRange.Fields.Max > US915_TX_MAX_DATARATE )
     {


### PR DESCRIPTION
The LoRaWAN-Regional-Parameters (1.1b) document, for AU915 and US915,
lists the channels 64 - 71 as having specific data rates which are not
zero. This change removes the check of dr_min == 0 for these channels.

Issue #163