### PR TITLE
lib/lora: Fix manual add of channels 64-71

### DIFF
--- a/lib/lora/mac/region/RegionAU915.c
+++ b/lib/lora/mac/region/RegionAU915.c
@@ -841,13 +841,19 @@ LoRaMacStatus_t RegionAU915ChannelManualAdd( ChannelAddParams_t* channelAdd )
         return LORAMAC_STATUS_PARAMETER_INVALID;
     }
 
-    // Validate the datarate range for min: must be DR_0
-    if( channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
+    // Validate the datarate range for min: must be DR_0 for channels 0-63
+    if( id < 64 && channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
     {
         drInvalid = true;
     }
     // Validate the datarate range for max: must be <= TX_MAX_DATARATE
     if( channelAdd->NewChannel->DrRange.Fields.Max > AU915_TX_MAX_DATARATE )
+    {
+        drInvalid = true;
+    }
+
+    // Sanity check that Min is not greater then Max
+    if (channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max)
     {
         drInvalid = true;
     }

--- a/lib/lora/mac/region/RegionUS915.c
+++ b/lib/lora/mac/region/RegionUS915.c
@@ -849,13 +849,19 @@ LoRaMacStatus_t RegionUS915ChannelManualAdd( ChannelAddParams_t* channelAdd )
         return LORAMAC_STATUS_PARAMETER_INVALID;
     }
 
-    // Validate the datarate range for min: must be DR_0
-    if( channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
+    // Validate the datarate range for min: must be DR_0 for channels 0-63
+    if( id < 64 && channelAdd->NewChannel->DrRange.Fields.Min != DR_0 )
     {
         drInvalid = true;
     }
     // Validate the datarate range for max: must be <= TX_MAX_DATARATE
     if( channelAdd->NewChannel->DrRange.Fields.Max > US915_TX_MAX_DATARATE )
+    {
+        drInvalid = true;
+    }
+
+    // Sanity check that Min is not greater then Max
+    if (channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max)
     {
         drInvalid = true;
     }


### PR DESCRIPTION
The LoRaWAN-Regional-Parameters document (1.02 and 1.1.), for AU915 and US915,
lists the channels 64 - 71 as having specific data rates which are not
zero. This change removes the check of dr_min == 0 for these channels when
they are added manually.

Also a simple sanity check is done for the dr range.

This commit is in response to issue #163 