### PR TITLE
LoRaWan EU433: Add support for the region EU433 with LoPy4

### DIFF
--- a/esp32/application.mk
+++ b/esp32/application.mk
@@ -205,6 +205,7 @@ APP_LIB_LORA_SRC_C = $(addprefix lib/lora/,\
 	mac/region/RegionAS923.c \
 	mac/region/RegionAU915.c \
 	mac/region/RegionCommon.c \
+	mac/region/RegionEU433.c \
 	mac/region/RegionEU868.c \
 	mac/region/RegionUS915.c \
 	system/delay.c \
@@ -336,7 +337,7 @@ APP_LDFLAGS += $(LDFLAGS) -T esp32_out.ld -T esp32.common.ld -T esp32.rom.ld -T 
 # add the application specific CFLAGS
 CFLAGS += $(APP_INC) -DMICROPY_NLR_SETJMP=1 -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H -DESP_PLATFORM -DFFCONF_H=\"lib/oofatfs/ffconf.h\"
 CFLAGS_SIGFOX += $(APP_INC) -DMICROPY_NLR_SETJMP=1 -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H -DESP_PLATFORM
-CFLAGS += -DREGION_AS923 -DREGION_AU915 -DREGION_EU868 -DREGION_US915
+CFLAGS += -DREGION_AS923 -DREGION_AU915 -DREGION_EU433 -DREGION_EU868 -DREGION_US915
 
 # Give the possibility to use LittleFs on /flash, otherwise  FatFs is used
 FS ?= ""

--- a/lib/lora/mac/region/Region.c
+++ b/lib/lora/mac/region/Region.c
@@ -286,6 +286,8 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 #define EU433_NEXT_CHANNEL( )                      EU433_CASE { return RegionEU433NextChannel( nextChanParams, channel, time, aggregatedTimeOff ); }
 #define EU433_CHANNEL_ADD( )                       EU433_CASE { return RegionEU433ChannelAdd( channelAdd ); }
 #define EU433_CHANNEL_REMOVE( )                    EU433_CASE { return RegionEU433ChannelsRemove( channelRemove ); }
+#define EU433_CHANNEL_MANUAL_ADD( )                EU433_CASE { return RegionEU433ChannelManualAdd( channelAdd ); }
+#define EU433_CHANNEL_MANUAL_REMOVE( )             EU433_CASE { return RegionEU433ChannelsRemove( channelRemove ); }
 #define EU433_SET_CONTINUOUS_WAVE( )               EU433_CASE { RegionEU433SetContinuousWave( continuousWave ); break; }
 #define EU433_APPLY_DR_OFFSET( )                   EU433_CASE { return RegionEU433ApplyDrOffset( downlinkDwellTime, dr, drOffset ); }
 #else
@@ -1035,6 +1037,7 @@ LoRaMacStatus_t RegionChannelManualAdd( LoRaMacRegion_t region, ChannelAddParams
     {
         AS923_CHANNEL_MANUAL_ADD( );
         AU915_CHANNEL_MANUAL_ADD( );
+        EU433_CHANNEL_MANUAL_ADD( );
         EU868_CHANNEL_MANUAL_ADD( );
         US915_CHANNEL_MANUAL_ADD( );
         US915_HYBRID_CHANNEL_MANUAL_ADD( );

--- a/lib/lora/mac/region/RegionEU433.c
+++ b/lib/lora/mac/region/RegionEU433.c
@@ -23,7 +23,7 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 #include <math.h>
 
 #include "board.h"
-#include "LoRaMac.h"
+#include "lora/mac/LoRaMac.h"
 #include "esp_attr.h"
 
 #include "utilities.h"
@@ -1007,6 +1007,75 @@ LoRaMacStatus_t RegionEU433ChannelAdd( ChannelAddParams_t* channelAdd )
     return LORAMAC_STATUS_OK;
 }
 
+LoRaMacStatus_t RegionEU433ChannelManualAdd( ChannelAddParams_t* channelAdd )
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= EU433_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( RegionCommonValueInRange( channelAdd->NewChannel->DrRange.Fields.Min, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == false )
+    {
+        drInvalid = true;
+    }
+    if( RegionCommonValueInRange( channelAdd->NewChannel->DrRange.Fields.Max, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == false )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < EU433_NUMB_DEFAULT_CHANNELS )
+    {
+        // Validate the datarate range for min: must be DR_0
+        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        {
+            drInvalid = true;
+        }
+        // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
+        if( RegionCommonValueInRange( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, EU433_TX_MAX_DATARATE ) == false )
+        {
+            drInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq( channelAdd->NewChannel->Frequency ) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
 bool RegionEU433ChannelsRemove( ChannelRemoveParams_t* channelRemove  )
 {
     uint8_t id = channelRemove->ChannelId;

--- a/lib/lora/mac/region/RegionEU433.h
+++ b/lib/lora/mac/region/RegionEU433.h
@@ -433,6 +433,15 @@ bool RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_t* channel,
 LoRaMacStatus_t RegionEU433ChannelAdd( ChannelAddParams_t* channelAdd );
 
 /*!
+ * \brief Adds a channel.
+ *
+ * \param [IN] channelAdd Pointer to the function parameters.
+ *
+ * \retval Status of the operation.
+ */
+LoRaMacStatus_t RegionEU433ChannelManualAdd( ChannelAddParams_t* channelAdd );
+
+/*!
  * \brief Removes a channel.
  *
  * \param [IN] channelRemove Pointer to the function parameters.


### PR DESCRIPTION
This Pr adds support for the EU433 regikon. It may only be used
with LoPy4.

Changed files:
application.mk  (just added the flag -DEU433)
mods/modlora.c  (handling all of the EU433 options)
../lib/lora/mac/region/Region.c  (just for manual channel add with frequency)
../lib/lora/mac/region/RegionEU433.c (just for manual channel add with frequency)
../lib/lora/mac/region/RegionEU433.h (just for manual channel add with frequency)

The PR is based on the developemnt version 1.19.0.b4