### PR TITLE
LoRaWan EU433: Add support for the region EU433 with LoPy4

### DIFF
--- a/esp32/application.mk
+++ b/esp32/application.mk
@@ -205,6 +205,7 @@ APP_LIB_LORA_SRC_C = $(addprefix lib/lora/,\
 	mac/region/RegionAS923.c \
 	mac/region/RegionAU915.c \
 	mac/region/RegionCommon.c \
+	mac/region/RegionEU433.c \
 	mac/region/RegionEU868.c \
 	mac/region/RegionUS915.c \
 	system/delay.c \
@@ -336,7 +337,7 @@ APP_LDFLAGS += $(LDFLAGS) -T esp32_out.ld -T esp32.common.ld -T esp32.rom.ld -T 
 # add the application specific CFLAGS
 CFLAGS += $(APP_INC) -DMICROPY_NLR_SETJMP=1 -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H -DESP_PLATFORM -DFFCONF_H=\"lib/oofatfs/ffconf.h\"
 CFLAGS_SIGFOX += $(APP_INC) -DMICROPY_NLR_SETJMP=1 -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H -DESP_PLATFORM
-CFLAGS += -DREGION_AS923 -DREGION_AU915 -DREGION_EU868 -DREGION_US915
+CFLAGS += -DREGION_AS923 -DREGION_AU915 -DREGION_EU433 -DREGION_EU868 -DREGION_US915
 
 # Give the possibility to use LittleFs on /flash, otherwise  FatFs is used
 FS ?= ""

--- a/esp32/application.mk
+++ b/esp32/application.mk
@@ -205,7 +205,6 @@ APP_LIB_LORA_SRC_C = $(addprefix lib/lora/,\
 	mac/region/RegionAS923.c \
 	mac/region/RegionAU915.c \
 	mac/region/RegionCommon.c \
-	mac/region/RegionEU433.c \
 	mac/region/RegionEU868.c \
 	mac/region/RegionUS915.c \
 	system/delay.c \
@@ -337,7 +336,7 @@ APP_LDFLAGS += $(LDFLAGS) -T esp32_out.ld -T esp32.common.ld -T esp32.rom.ld -T 
 # add the application specific CFLAGS
 CFLAGS += $(APP_INC) -DMICROPY_NLR_SETJMP=1 -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H -DESP_PLATFORM -DFFCONF_H=\"lib/oofatfs/ffconf.h\"
 CFLAGS_SIGFOX += $(APP_INC) -DMICROPY_NLR_SETJMP=1 -DMBEDTLS_CONFIG_FILE='"mbedtls/esp_config.h"' -DHAVE_CONFIG_H -DESP_PLATFORM
-CFLAGS += -DREGION_AS923 -DREGION_AU915 -DREGION_EU433 -DREGION_EU868 -DREGION_US915
+CFLAGS += -DREGION_AS923 -DREGION_AU915 -DREGION_EU868 -DREGION_US915
 
 # Give the possibility to use LittleFs on /flash, otherwise  FatFs is used
 FS ?= ""
@@ -374,6 +373,9 @@ SHELL    = bash
 
 BOOT_BIN = $(BUILD)/bootloader/bootloader.bin
 
+ifeq ($(BOARD), ESP32)
+    APP_BIN = $(BUILD)/wipy.bin
+endif
 ifeq ($(BOARD), WIPY)
     APP_BIN = $(BUILD)/wipy.bin
 endif
@@ -382,6 +384,8 @@ ifeq ($(BOARD), LOPY)
 endif
 ifeq ($(BOARD), LOPY4)
     APP_BIN = $(BUILD)/lopy4.bin
+    CFLAGS += -DREGION_EU433
+    APP_LIB_LORA_SRC_C += lib/lora/mac/region/RegionEU433.c
     $(BUILD)/sigfox/radio_sx127x.o: CFLAGS = $(CFLAGS_SIGFOX)
     $(BUILD)/sigfox/timer.o: CFLAGS = $(CFLAGS_SIGFOX)
     $(BUILD)/sigfox/transmission.o: CFLAGS = $(CFLAGS_SIGFOX)

--- a/esp32/mods/modlora.c
+++ b/esp32/mods/modlora.c
@@ -52,7 +52,9 @@
 #include "lora/mac/region/RegionUS915.h"
 #include "lora/mac/region/RegionUS915-Hybrid.h"
 #include "lora/mac/region/RegionEU868.h"
+#if defined(REGION_EU433)
 #include "lora/mac/region/RegionEU433.h"
+#endif
 
 // openThread includes
 #include <openthread/udp.h>
@@ -1219,11 +1221,13 @@ static void lora_validate_frequency (uint32_t frequency) {
                 goto freq_error;
             }
             break;
+#if defined(REGION_EU433)
         case LORAMAC_REGION_EU433:
             if (frequency < 433000000 || frequency > 435000000) { // LoRa 433 - 434
                 goto freq_error;
             }
             break;
+#endif
         case LORAMAC_REGION_EU868:
             if (frequency < 863000000 || frequency > 870000000) {
                 goto freq_error;
@@ -1260,11 +1264,13 @@ static void lora_validate_channel (uint32_t index) {
                 goto channel_error;
             }
             break;
+#if defined(REGION_EU433)
         case LORAMAC_REGION_EU433:
             if (index >= EU433_MAX_NB_CHANNELS) {
                 goto channel_error;
             }
             break;
+#endif
         case LORAMAC_REGION_EU868:
             if (index >= EU868_MAX_NB_CHANNELS) {
                 goto channel_error;
@@ -1288,8 +1294,10 @@ static void lora_validate_power (uint8_t tx_power) {
 static bool lora_validate_data_rate (uint32_t data_rate) {
 
     switch (lora_obj.region) {
-    case LORAMAC_REGION_AS923:
+#if defined(REGION_EU433)
     case LORAMAC_REGION_EU433:
+#endif    
+    case LORAMAC_REGION_AS923:
     case LORAMAC_REGION_EU868:
     case LORAMAC_REGION_AU915:
         if (data_rate > DR_6) {
@@ -1342,7 +1350,7 @@ static void lora_validate_device_class (DeviceClass_t device_class) {
 static void lora_validate_region (LoRaMacRegion_t region) {
     if (region != LORAMAC_REGION_AS923 && region != LORAMAC_REGION_AU915
         && region != LORAMAC_REGION_EU868 && region != LORAMAC_REGION_US915
-#if defined(LOPY4)
+#if defined(REGION_EU433)
         && region != LORAMAC_REGION_EU433
 #endif
         ) {
@@ -1562,9 +1570,11 @@ static mp_obj_t lora_init_helper(lora_obj_t *self, const mp_arg_val_t *args) {
         case LORAMAC_REGION_EU868:
             cmd_data.info.init.frequency = 868100000;
             break;
+#if defined(REGION_EU433)
         case LORAMAC_REGION_EU433:
             cmd_data.info.init.frequency = 433175000;
             break;
+#endif
         default:
             break;
         }
@@ -1584,9 +1594,11 @@ static mp_obj_t lora_init_helper(lora_obj_t *self, const mp_arg_val_t *args) {
         case LORAMAC_REGION_EU868:
             cmd_data.info.init.tx_power = 14;
             break;
+#if defined(REGION_EU433)
         case LORAMAC_REGION_EU433:
             cmd_data.info.init.tx_power = 12;
             break;
+#endif
         default:
             break;
         }
@@ -1745,7 +1757,9 @@ STATIC mp_obj_t lora_join(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *
         dr = DR_4;
         break;
     case LORAMAC_REGION_EU868:
+#if defined(REGION_EU433)
     case LORAMAC_REGION_EU433:
+#endif
         dr = DR_5;
         break;
     default:
@@ -1777,7 +1791,9 @@ STATIC mp_obj_t lora_join(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *
             }
             break;
         case LORAMAC_REGION_EU868:
+#if defined(REGION_EU433)
         case LORAMAC_REGION_EU433:
+#endif
             if (dr > DR_5) {
                 goto dr_error;
             }
@@ -2371,8 +2387,10 @@ STATIC const mp_map_elem_t lora_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_AS923),               MP_OBJ_NEW_SMALL_INT(LORAMAC_REGION_AS923) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_AU915),               MP_OBJ_NEW_SMALL_INT(LORAMAC_REGION_AU915) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_EU868),               MP_OBJ_NEW_SMALL_INT(LORAMAC_REGION_EU868) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_EU433),               MP_OBJ_NEW_SMALL_INT(LORAMAC_REGION_EU433) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_US915),               MP_OBJ_NEW_SMALL_INT(LORAMAC_REGION_US915) },
+#if defined(REGION_EU433)
+    { MP_OBJ_NEW_QSTR(MP_QSTR_EU433),               MP_OBJ_NEW_SMALL_INT(LORAMAC_REGION_EU433) },
+#endif
 };
 
 STATIC MP_DEFINE_CONST_DICT(lora_locals_dict, lora_locals_dict_table);
@@ -2416,7 +2434,9 @@ static int lora_socket_socket (mod_network_socket_obj_t *s, int *_errno) {
     switch (lora_obj.region) {
     case LORAMAC_REGION_AS923:
     case LORAMAC_REGION_EU868:
+#if defined(REGION_EU433)
     case LORAMAC_REGION_EU433:
+#endif
         dr = DR_5;
         break;
     case LORAMAC_REGION_AU915:

--- a/esp32/mods/modutime.c
+++ b/esp32/mods/modutime.c
@@ -167,7 +167,7 @@ STATIC mp_obj_t time_ticks_cpu(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(time_ticks_cpu_obj, time_ticks_cpu);
 
-STATIC mp_obj_t time_ticks_diff(mp_obj_t end_in, mp_obj_t start_in) {
+STATIC mp_obj_t time_ticks_diff(mp_obj_t start_in, mp_obj_t end_in) {
     int32_t start = mp_obj_get_int_truncated(start_in);
     int32_t end = mp_obj_get_int_truncated(end_in);
     return mp_obj_new_int(end - start);

--- a/lib/lora/mac/region/Region.c
+++ b/lib/lora/mac/region/Region.c
@@ -311,6 +311,7 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 #define EU433_CALC_BACKOFF( )
 #define EU433_NEXT_CHANNEL( )
 #define EU433_CHANNEL_ADD( )
+#define EU433_CHANNEL_MANUAL_ADD( )
 #define EU433_CHANNEL_REMOVE( )
 #define EU433_SET_CONTINUOUS_WAVE( )
 #define EU433_APPLY_DR_OFFSET( )

--- a/lib/lora/mac/region/Region.c
+++ b/lib/lora/mac/region/Region.c
@@ -290,6 +290,9 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 #define EU433_CHANNEL_MANUAL_REMOVE( )             EU433_CASE { return RegionEU433ChannelsRemove( channelRemove ); }
 #define EU433_SET_CONTINUOUS_WAVE( )               EU433_CASE { RegionEU433SetContinuousWave( continuousWave ); break; }
 #define EU433_APPLY_DR_OFFSET( )                   EU433_CASE { return RegionEU433ApplyDrOffset( downlinkDwellTime, dr, drOffset ); }
+#define EU433_GET_CHANNELS( )                      EU433_CASE { return RegionEU433GetChannels( channels, size ); }
+#define EU433_GET_CHANNEL_MASK( )                  EU433_CASE { return RegionEU433GetChannelMask( channelmask, size ); }
+#define EU433_FORCE_JOIN_DATARATE( )               EU433_CASE { return RegionEU433ForceJoinDataRate( joinDr, alternateDr ); }
 #else
 #define EU433_IS_ACTIVE( )
 #define EU433_GET_PHY_PARAM( )
@@ -313,8 +316,12 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 #define EU433_CHANNEL_ADD( )
 #define EU433_CHANNEL_MANUAL_ADD( )
 #define EU433_CHANNEL_REMOVE( )
+#define EU433_CHANNEL_MANUAL_REMOVE( )
 #define EU433_SET_CONTINUOUS_WAVE( )
 #define EU433_APPLY_DR_OFFSET( )
+#define EU433_GET_CHANNELS( )
+#define EU433_GET_CHANNEL_MASK( )
+#define EU433_FORCE_JOIN_DATARATE( )
 #endif
 
 #ifdef REGION_EU868
@@ -1077,6 +1084,7 @@ bool RegionChannelsManualRemove( LoRaMacRegion_t region, ChannelRemoveParams_t* 
         AS923_CHANNEL_MANUAL_REMOVE( );
         AU915_CHANNEL_MANUAL_REMOVE( );
         EU868_CHANNEL_MANUAL_REMOVE( );
+        EU433_CHANNEL_MANUAL_REMOVE( );
         US915_CHANNEL_MANUAL_REMOVE( );
         US915_HYBRID_CHANNEL_MANUAL_REMOVE( );
         default:
@@ -1135,6 +1143,7 @@ bool RegionGetChannels( LoRaMacRegion_t region, ChannelParams_t** channels, uint
         AS923_GET_CHANNELS( );
         AU915_GET_CHANNELS( );
         EU868_GET_CHANNELS( );
+        EU433_GET_CHANNELS( );
         US915_GET_CHANNELS( );
         US915_HYBRID_GET_CHANNELS( );
         default:
@@ -1150,6 +1159,7 @@ bool RegionGetChannelMask(LoRaMacRegion_t region, uint16_t **channelmask, uint32
         AS923_GET_CHANNEL_MASK( );
         AU915_GET_CHANNEL_MASK( );
         EU868_GET_CHANNEL_MASK( );
+        EU433_GET_CHANNEL_MASK( );
         US915_GET_CHANNEL_MASK( );
         US915_HYBRID_GET_CHANNEL_MASK( );
         default:
@@ -1179,6 +1189,7 @@ bool RegionForceJoinDataRate( LoRaMacRegion_t region, int8_t joinDr, AlternateDr
         AS923_FORCE_JOIN_DATARATE( );
         AU915_FORCE_JOIN_DATARATE( );
         EU868_FORCE_JOIN_DATARATE( );
+        EU433_FORCE_JOIN_DATARATE( );
         US915_FORCE_JOIN_DATARATE( );
         US915_HYBRID_FORCE_JOIN_DATARATE( );
         default:

--- a/lib/lora/mac/region/Region.c
+++ b/lib/lora/mac/region/Region.c
@@ -286,6 +286,8 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 #define EU433_NEXT_CHANNEL( )                      EU433_CASE { return RegionEU433NextChannel( nextChanParams, channel, time, aggregatedTimeOff ); }
 #define EU433_CHANNEL_ADD( )                       EU433_CASE { return RegionEU433ChannelAdd( channelAdd ); }
 #define EU433_CHANNEL_REMOVE( )                    EU433_CASE { return RegionEU433ChannelsRemove( channelRemove ); }
+#define EU433_CHANNEL_MANUAL_ADD( )                EU433_CASE { return RegionEU433ChannelManualAdd( channelAdd ); }
+#define EU433_CHANNEL_MANUAL_REMOVE( )             EU433_CASE { return RegionEU433ChannelsRemove( channelRemove ); }
 #define EU433_SET_CONTINUOUS_WAVE( )               EU433_CASE { RegionEU433SetContinuousWave( continuousWave ); break; }
 #define EU433_APPLY_DR_OFFSET( )                   EU433_CASE { return RegionEU433ApplyDrOffset( downlinkDwellTime, dr, drOffset ); }
 #else
@@ -1035,6 +1037,7 @@ LoRaMacStatus_t RegionChannelManualAdd( LoRaMacRegion_t region, ChannelAddParams
     {
         AS923_CHANNEL_MANUAL_ADD( );
         AU915_CHANNEL_MANUAL_ADD( );
+        EU433_CHANNEL_MANUAL_ADD( );
         EU868_CHANNEL_MANUAL_ADD( );
         US915_CHANNEL_MANUAL_ADD( );
         US915_HYBRID_CHANNEL_MANUAL_ADD( );

--- a/lib/lora/mac/region/RegionEU433.c
+++ b/lib/lora/mac/region/RegionEU433.c
@@ -23,7 +23,7 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 #include <math.h>
 
 #include "board.h"
-#include "LoRaMac.h"
+#include "lora/mac/LoRaMac.h"
 #include "esp_attr.h"
 
 #include "utilities.h"
@@ -1007,6 +1007,75 @@ LoRaMacStatus_t RegionEU433ChannelAdd( ChannelAddParams_t* channelAdd )
     return LORAMAC_STATUS_OK;
 }
 
+LoRaMacStatus_t RegionEU433ChannelManualAdd( ChannelAddParams_t* channelAdd )
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= EU433_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( RegionCommonValueInRange( channelAdd->NewChannel->DrRange.Fields.Min, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == false )
+    {
+        drInvalid = true;
+    }
+    if( RegionCommonValueInRange( channelAdd->NewChannel->DrRange.Fields.Max, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == false )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < EU433_NUMB_DEFAULT_CHANNELS )
+    {
+        // Validate the datarate range for min: must be DR_0
+        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        {
+            drInvalid = true;
+        }
+        // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
+        if( RegionCommonValueInRange( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, EU433_TX_MAX_DATARATE ) == false )
+        {
+            drInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq( channelAdd->NewChannel->Frequency ) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
 bool RegionEU433ChannelsRemove( ChannelRemoveParams_t* channelRemove  )
 {
     uint8_t id = channelRemove->ChannelId;

--- a/lib/lora/mac/region/RegionEU433.c
+++ b/lib/lora/mac/region/RegionEU433.c
@@ -1113,3 +1113,25 @@ uint8_t RegionEU433ApplyDrOffset( uint8_t downlinkDwellTime, int8_t dr, int8_t d
     }
     return datarate;
 }
+bool RegionEU433GetChannels( ChannelParams_t** channels, uint32_t *size )
+{
+    *channels = Channels;
+    *size = sizeof(Channels);
+    return true;
+}
+
+bool RegionEU433GetChannelMask( uint16_t** channelmask, uint32_t *size )
+{
+    *channelmask = ChannelsMask;
+    *size = sizeof(ChannelsMask);
+    return true;
+}
+
+bool RegionEU433ForceJoinDataRate( int8_t joinDr, AlternateDrParams_t* alternateDr )
+{
+    uint8_t DRToCounter[6] = { 48, 32, 24, 16, 8, 1 };
+    if (joinDr < sizeof(DRToCounter)) {
+        alternateDr->NbTrials = DRToCounter[joinDr];
+    }
+    return true;
+}

--- a/lib/lora/mac/region/RegionEU433.h
+++ b/lib/lora/mac/region/RegionEU433.h
@@ -433,6 +433,15 @@ bool RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_t* channel,
 LoRaMacStatus_t RegionEU433ChannelAdd( ChannelAddParams_t* channelAdd );
 
 /*!
+ * \brief Adds a channel.
+ *
+ * \param [IN] channelAdd Pointer to the function parameters.
+ *
+ * \retval Status of the operation.
+ */
+LoRaMacStatus_t RegionEU433ChannelManualAdd( ChannelAddParams_t* channelAdd );
+
+/*!
  * \brief Removes a channel.
  *
  * \param [IN] channelRemove Pointer to the function parameters.

--- a/lib/lora/mac/region/RegionEU433.h
+++ b/lib/lora/mac/region/RegionEU433.h
@@ -470,6 +470,12 @@ void RegionEU433SetContinuousWave( ContinuousWaveParams_t* continuousWave );
  */
 uint8_t RegionEU433ApplyDrOffset( uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
 
+bool RegionEU433GetChannels( ChannelParams_t** channels, uint32_t *size );
+
+bool RegionEU433GetChannelMask( uint16_t** channelmask, uint32_t *size );
+
+bool RegionEU433ForceJoinDataRate( int8_t joinDr, AlternateDrParams_t* alternateDr );
+
 /*! \} defgroup REGIONEU433 */
 
 #endif // __REGION_EU433_H__


### PR DESCRIPTION
This Pr adds support for the EU433 region. It may only be used
with LoPy4.

Changed files:
application.mk  (just added the flag -DEU433)
mods/modlora.c  (handling all of the EU433 options)
../lib/lora/mac/region/Region.c  (just for manual channel add with frequency)
../lib/lora/mac/region/RegionEU433.c (just for manual channel add with frequency)
../lib/lora/mac/region/RegionEU433.h (just for manual channel add with frequency)

The PR is based on the development version 1.19.0.b4