### PR TITLE
Allow binding to LoRa mesh addresses

### DIFF
--- a/esp32/lora/ot-task.c
+++ b/esp32/lora/ot-task.c
@@ -163,7 +163,7 @@ int mesh_socket_bind(byte *ip, mp_uint_t port, int *_errno) {
     memset(&sockaddr, 0, sizeof(sockaddr));
 
     otEXPECT_ACTION(
-            OT_ERROR_NONE == otIp6AddressFromString("::", &sockaddr.mAddress),
+            OT_ERROR_NONE == otIp6AddressFromString((const char*) ip, &sockaddr.mAddress),
             *_errno = MP_ENOENT);
 
     sockaddr.mPort = port;

--- a/esp32/mods/modusocket.c
+++ b/esp32/mods/modusocket.c
@@ -262,10 +262,23 @@ STATIC mp_obj_t socket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
 
 #if defined (LOPY) || defined(LOPY4) || defined(FIPY)
     if (self->sock_base.nic_type == &mod_network_nic_type_lora) {
-        mp_uint_t port = mp_obj_get_int(addr_in);
-
-        if (self->sock_base.nic_type->n_bind(self, NULL, port, &_errno) != 0) {
-            nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(_errno)));
+        if (MP_OBJ_IS_INT(addr_in)) {
+            mp_uint_t port = mp_obj_get_int(addr_in);
+            if (self->sock_base.nic_type->n_bind(self, (unsigned char*) "::", port, &_errno) != 0) {
+                nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(_errno)));
+            }
+        } else {
+            uint8_t ip[MOD_USOCKET_IPV6_CHARS_MAX];
+            mp_obj_t *addr_items;
+            mp_obj_get_array_fixed_n(addr_in, 2, &addr_items);
+            size_t addr_len;
+            const char *addr_str = mp_obj_str_get_data(addr_items[0], &addr_len);
+            addr_len++; //string end null char
+            memcpy(ip, addr_str, (addr_len< MOD_USOCKET_IPV6_CHARS_MAX)?addr_len:MOD_USOCKET_IPV6_CHARS_MAX);
+            mp_uint_t port = mp_obj_get_int(addr_items[1]);
+            if (self->sock_base.nic_type->n_bind(self, ip, port, &_errno) != 0) {
+                nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(_errno)));
+            }
         }
     } else {
 #endif


### PR DESCRIPTION
The current LoRa mesh doesn't allow binding to an address, only the port.  Because of this it's impossible to send packets from the mesh-local EID, only the RLOC16-based addresses.  That's not ideal because the RLOC16-based address will change periodically.  This change allows binding to other addresses, potentially ones that don't change.