### PR TITLE
utime: Revert back the ticks_xxx functions to use short ints.

### DIFF
--- a/esp32/hal/esp32_mphal.c
+++ b/esp32/hal/esp32_mphal.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "py/smallint.h"
 #include "py/mpstate.h"
 #include "py/mphal.h"
 #include "py/runtime.h"
@@ -178,7 +179,7 @@ IRAM_ATTR uint64_t mp_hal_ticks_ms_non_blocking(void) {
 }
 
 IRAM_ATTR uint64_t mp_hal_ticks_us_non_blocking(void) {
-    return esp_timer_get_time();
+    return esp_timer_get_time() & (MICROPY_PY_UTIME_TICKS_PERIOD - 1);
 }
 
 void mp_hal_delay_ms(uint32_t delay) {

--- a/esp32/mods/modutime.c
+++ b/esp32/mods/modutime.c
@@ -44,6 +44,7 @@
 #include "py/gc.h"
 #include "py/runtime.h"
 #include "py/mphal.h"
+#include "extmod/utime_mphal.h"
 #include "py/smallint.h"
 #include "machrtc.h"
 #include "machtimer.h"
@@ -132,54 +133,10 @@ STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(time_mktime_obj, time_mktime);
 
-/// \function sleep(seconds)
-/// Sleep for the given number of seconds.
-STATIC mp_obj_t time_sleep(mp_obj_t seconds_o) {
-    mp_hal_delay_ms(1000 * mp_obj_get_float(seconds_o));
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_1(time_sleep_obj, time_sleep);
-
-STATIC mp_obj_t time_sleep_ms(mp_obj_t arg) {
-    mp_hal_delay_ms(mp_obj_get_int(arg));
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_sleep_ms_obj, time_sleep_ms);
-
-STATIC mp_obj_t time_sleep_us(mp_obj_t arg) {
-    mp_hal_delay_us(mp_obj_get_int(arg));
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_sleep_us_obj, time_sleep_us);
-
-STATIC mp_obj_t time_ticks_ms(void) {
-    return mp_obj_new_int_from_uint(mp_hal_ticks_ms());
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(time_ticks_ms_obj, time_ticks_ms);
-
-STATIC mp_obj_t time_ticks_us(void) {
-    return mp_obj_new_int_from_uint(mp_hal_ticks_us());
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(time_ticks_us_obj, time_ticks_us);
-
 STATIC mp_obj_t time_ticks_cpu(void) {
-   return mp_obj_new_int_from_uint(mp_hal_ticks_us_non_blocking());
+   return MP_OBJ_NEW_SMALL_INT(mp_hal_ticks_us_non_blocking());
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(time_ticks_cpu_obj, time_ticks_cpu);
-
-STATIC mp_obj_t time_ticks_diff(mp_obj_t end_in, mp_obj_t start_in) {
-    int32_t start = mp_obj_get_int_truncated(start_in);
-    int32_t end = mp_obj_get_int_truncated(end_in);
-    return mp_obj_new_int(end - start);
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(time_ticks_diff_obj, time_ticks_diff);
-
-STATIC mp_obj_t time_ticks_add(mp_obj_t start_in, mp_obj_t delta_in) {
-    uint32_t start = mp_obj_get_int_truncated(start_in);
-    uint32_t delta = mp_obj_get_int_truncated(delta_in);
-    return mp_obj_new_int_from_uint(start + delta);
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(time_ticks_add_obj, time_ticks_add);
 
 /// \function time()
 /// Returns the number of seconds, as an integer, since 1/1/1970.
@@ -207,14 +164,14 @@ STATIC const mp_map_elem_t time_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_localtime),           (mp_obj_t)&time_localtime_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_gmtime),              (mp_obj_t)&time_gmtime_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_mktime),              (mp_obj_t)&time_mktime_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_sleep),               (mp_obj_t)&time_sleep_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_sleep_ms),            (mp_obj_t)&time_sleep_ms_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_sleep_us),            (mp_obj_t)&time_sleep_us_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_ms),            (mp_obj_t)&time_ticks_ms_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_us),            (mp_obj_t)&time_ticks_us_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_sleep),               (mp_obj_t)&mp_utime_sleep_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_sleep_ms),            (mp_obj_t)&mp_utime_sleep_ms_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_sleep_us),            (mp_obj_t)&mp_utime_sleep_us_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_ms),            (mp_obj_t)&mp_utime_ticks_ms_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_us),            (mp_obj_t)&mp_utime_ticks_us_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_cpu),           (mp_obj_t)&time_ticks_cpu_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_add),           (mp_obj_t)&time_ticks_add_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_diff),          (mp_obj_t)&time_ticks_diff_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_add),           (mp_obj_t)&mp_utime_ticks_add_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ticks_diff),          (mp_obj_t)&mp_utime_ticks_diff_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_time),                (mp_obj_t)&time_time_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_timezone),            (mp_obj_t)&time_timezone_obj },
 };

--- a/esp32/mpconfigport.h
+++ b/esp32/mpconfigport.h
@@ -122,6 +122,7 @@
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF      (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE        (0)
 #define MICROPY_KBD_EXCEPTION                       (1)
+#define MICROPY_PY_UTIME_MP_HAL                     (1)
 
 #ifndef BOOTLOADER_BUILD
 #include "freertos/FreeRTOS.h"


### PR DESCRIPTION
The ticks_xx functions wrap around at a certain value. For the initial micropython, this values is 2^30-1 (MP short int). For the pycom port, it is 2^32-1. Thats done by simply using C 32 bit integers. This implementation has two drawbacks:
-    uasyncio expects timers to be MP short ints.
-    using 32 bit ints cause the values to be standard ints in Python, which are more time-consuming 
     to deal with. That may hurt if for instance ticks_diff and ticks_xx are used a tight timing loop.
So this PR just goes back to the initial code, with was still present in the codebase and just had to be enabled with a config flag in mpconfigport.h.
Only ticks_cpu() is kept, limited to a 2^30 period, since different from the mp.org version is counts us ticks and the timing call is also used by the SX1272 and SX1276 driver. Side effects on the Lora nanogateway have to be tested yet, but I am pretty confident that it works. The ticks_cpu() call itself behaves well with ticks_diff().