### PR TITLE
help: Simplify and extend help()

### DIFF
--- a/esp32/mods/machspi.c
+++ b/esp32/mods/machspi.c
@@ -195,8 +195,8 @@ STATIC void pybspi_transfer (mach_spi_obj_t *self, const char *txdata, char *rxd
     for (int i = 0; i < len; i += self->wlen) {
         uint32_t _rxdata = 0;
         uint32_t _txdata;
-        if (txdata) {
-            memcpy(&_txdata, &txdata[i], self->wlen);
+        if (txchar) {
+            _txdata = *txchar;
         } else {
             _txdata = 0x55555555;
         }

--- a/esp32/mods/machspi.c
+++ b/esp32/mods/machspi.c
@@ -195,10 +195,14 @@ STATIC void pybspi_transfer (mach_spi_obj_t *self, const char *txdata, char *rxd
     for (int i = 0; i < len; i += self->wlen) {
         uint32_t _rxdata = 0;
         uint32_t _txdata;
-        if (txchar) {
-            _txdata = *txchar;
+        if (txdata) {
+            memcpy(&_txdata, &txdata[i], self->wlen);
         } else {
-            _txdata = 0x55555555;
+            if (txchar) {
+                _txdata = *txchar;
+            } else {
+                _txdata = 0x55555555;
+            }
         }
         spi_data_t spidata = {.cmd = 0, .cmdLen = 0, .addr = NULL, .addrLen = 0,
                                 .txData = &_txdata, .txDataLen = self->wlen,

--- a/esp32/mpconfigport.h
+++ b/esp32/mpconfigport.h
@@ -53,6 +53,8 @@
 #define MICROPY_STACK_CHECK                         (1)
 #define MICROPY_HELPER_REPL                         (1)
 #define MICROPY_PY_BUILTINS_HELP                    (1)
+#define MICROPY_PY_BUILTINS_HELP_MODULES            (1)
+#define MICROPY_PY_BUILTINS_HELP_TEXT               pycom_help_text
 #define MICROPY_HELPER_LEXER_UNIX                   (0)
 #define MICROPY_ENABLE_SOURCE_LINE                  (1)
 #define MICROPY_MODULE_WEAK_LINKS                   (1)

--- a/esp32/util/help.c
+++ b/esp32/util/help.c
@@ -35,13 +35,8 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 
-#include "py/mpconfig.h"
-#include "py/obj.h"
-
-
-STATIC const char help_text[] =
+const char pycom_help_text[] =
     "Welcome to MicroPython!\n"
     "For online docs please visit http://docs.pycom.io\n"
     "\n"
@@ -53,49 +48,7 @@ STATIC const char help_text[] =
     "  CTRL-E        -- on a blank line, enter paste mode\n"
     "  CTRL-F        -- on a blank line, do a hard reset of the board and enter safe boot\n"
     "\n"
-    "For further help on a specific object, type help(obj)\n";
+    "For further help on a specific object, type help(obj)\n"
+    "For a list of available modules, type help('modules')\n"
+    ;
 
-STATIC void pyb_help_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
-    mp_printf(&mp_plat_print, "  ");
-    mp_obj_print(name_o, PRINT_STR);
-    mp_printf(&mp_plat_print, " -- ");
-    mp_obj_print(value, PRINT_STR);
-    mp_printf(&mp_plat_print, "\n");
-}
-
-STATIC mp_obj_t pyb_help(uint n_args, const mp_obj_t *args) {
-    if (n_args == 0) {
-        // print a general help message
-        mp_printf(&mp_plat_print, "%s", help_text);
-    }
-    else {
-        // try to print something sensible about the given object
-        mp_printf(&mp_plat_print, "object ");
-        mp_obj_print(args[0], PRINT_STR);
-        mp_printf(&mp_plat_print, " is of type %s\n", mp_obj_get_type_str(args[0]));
-
-        mp_map_t *map = NULL;
-        if (MP_OBJ_IS_TYPE(args[0], &mp_type_module)) {
-            map = mp_obj_dict_get_map(mp_obj_module_get_globals(args[0]));
-        } else {
-            mp_obj_type_t *type;
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
-                type = args[0];
-            } else {
-                type = mp_obj_get_type(args[0]);
-            }
-            if (type->locals_dict != MP_OBJ_NULL && MP_OBJ_IS_TYPE(type->locals_dict, &mp_type_dict)) {
-                map = mp_obj_dict_get_map(type->locals_dict);
-            }
-        }
-        if (map != NULL) {
-            for (uint i = 0; i < map->alloc; i++) {
-                if (map->table[i].key != MP_OBJ_NULL) {
-                    pyb_help_print_info_about_object(map->table[i].key, map->table[i].value);
-                }
-            }
-        }
-    }
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_help_obj, 0, 1, pyb_help);


### PR DESCRIPTION
Replace the port specific implementation for help() by the builtin version,
which merely consist of deleting all code but the specific help message.
At the same time, enable help('modules') to show a list of all builtin
and frozen module.