### PR TITLE
build config: make openthread over lora a build-time configuration option

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -36,6 +36,9 @@ RELEASE_DIR ?= build/
 
 COPY_IDF_LIB ?= 0
 
+# by default openthread over LoRa is enabled
+OPENTHREAD ?= on
+
 # by default Secure Boot and Flash Encryption are disabled
 SECURE ?= off
 
@@ -97,7 +100,7 @@ LIBS = -L$(ESP_IDF_COMP_PATH)/esp32/lib -L$(ESP_IDF_COMP_PATH)/esp32/ld -L$(ESP_
        $(ESP_IDF_COMP_PATH)/newlib/lib/libm-psram-workaround.a \
        $(ESP_IDF_COMP_PATH)/newlib/lib/libc-psram-workaround.a \
        -lfreertos -ljson -ljsmn -llwip -lnewlib -lvfs -lopenssl -lmbedtls -lwpa_supplicant \
-       -lxtensa-debug-module -lbt -lsdmmc -lsoc -lheap -lbootloader_support -lmicro-ecc -lopenthread \
+       -lxtensa-debug-module -lbt -lsdmmc -lsoc -lheap -lbootloader_support -lmicro-ecc \
 			 -u ld_include_panic_highint_hdl -lsmartconfig_ack -lmesh
 ifeq ($(BOARD), $(filter $(BOARD), FIPY))
     LIBS += sigfox/modsigfox_fipy.a
@@ -109,6 +112,11 @@ endif
 
 ifeq ($(BOARD), $(filter $(BOARD), SIPY))
     LIBS += sigfox/modsigfox_sipy.a
+endif
+
+ifeq ($(OPENTHREAD), on)
+    LIBS += -lopenthread
+    CFLAGS += -DLORA_OPENTHREAD_ENABLED
 endif
 
 B_LIBS = -Lbootloader/lib -Lbootloader -L$(BUILD)/bootloader -L$(ESP_IDF_COMP_PATH)/esp32/ld \

--- a/esp32/mptask.c
+++ b/esp32/mptask.c
@@ -50,7 +50,9 @@
 
 #if defined (LOPY) || defined (LOPY4) || defined (FIPY)
 #include "modlora.h"
+#ifdef LORA_OPENTHREAD_ENABLED
 #include "lora/ot-task.h"
+#endif  // #ifdef LORA_OPENTHREAD_ENABLED
 #endif
 #if defined (SIPY) || defined(LOPY4) || defined (FIPY)
 #include "sigfox/modsigfox.h"
@@ -243,7 +245,9 @@ soft_reset:
         // these ones are special because they need uPy running and they launch tasks
 #if defined(LOPY) || defined (LOPY4) || defined (FIPY)
         modlora_init0();
+#  ifdef LORA_OPENTHREAD_ENABLED
         openthread_task_init();
+#  endif  // #ifdef LORA_OPENTHREAD_ENABLED
 #endif
 #if defined(SIPY) || defined(LOPY4) || defined (FIPY)
         modsigfox_init0();


### PR DESCRIPTION
Adds a make variable to disable openthread. By default it's still enabled.
To disable it, add `OPENTHREAD=off` to the `make` invocation.
This shaves off 160KB of the .bin, making the firmware fit again in the old OTA slot size of 1536KB.