### PR TITLE
py/modbuiltins: add missing TimeoutError

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -689,6 +689,9 @@ STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NameError), MP_ROM_PTR(&mp_type_NameError) },
     { MP_ROM_QSTR(MP_QSTR_NotImplementedError), MP_ROM_PTR(&mp_type_NotImplementedError) },
     { MP_ROM_QSTR(MP_QSTR_OSError), MP_ROM_PTR(&mp_type_OSError) },
+    #if MICROPY_PY_BUILTINS_TIMEOUTERROR
+    { MP_ROM_QSTR(MP_QSTR_TimeoutError), MP_ROM_PTR(&mp_type_TimeoutError) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_OverflowError), MP_ROM_PTR(&mp_type_OverflowError) },
     { MP_ROM_QSTR(MP_QSTR_RuntimeError), MP_ROM_PTR(&mp_type_RuntimeError) },
     #if MICROPY_PY_ASYNC_AWAIT


### PR DESCRIPTION
Cherry pick of https://github.com/micropython/micropython/pull/4428

Fixes https://github.com/pycom/pycom-micropython-sigfox/issues/251

cc @iwahdan88 / @Xykon 