### PR TITLE
Fixed delays causing not to achieve low power after deepsleep

### DIFF
--- a/esp32/lte/lteppp.c
+++ b/esp32/lte/lteppp.c
@@ -277,14 +277,10 @@ lte_legacy_t lteppp_get_legacy(void) {
 }
 
 void lteppp_deinit (void) {
-
-    // enable airplane low power mode
-    lteppp_send_at_cmd("AT!=\"setlpm airplane=1 enable=1\"", LTE_RX_TIMEOUT_MAX_MS);
-
     uart_set_hw_flow_ctrl(LTE_UART_ID, UART_HW_FLOWCTRL_DISABLE, 0);
     uart_set_rts(LTE_UART_ID, false);
     xSemaphoreTake(xLTESem, portMAX_DELAY);
-    lteppp_lte_state = E_LTE_INIT;
+    lteppp_lte_state = E_LTE_DEINIT;
     xSemaphoreGive(xLTESem);
 }
 
@@ -392,11 +388,7 @@ static void TASK_LTE (void *pvParameters) {
         }
     }
 
-    // disable PSM if enabled by default
-    lteppp_send_at_cmd("AT+CPSMS?", LTE_RX_TIMEOUT_MAX_MS);
-    if (!strstr(lteppp_trx_buffer, "+CPSMS: 0")) {
-        lteppp_send_at_cmd("AT+CPSMS=0", LTE_RX_TIMEOUT_MIN_MS);
-    }
+
     // enable airplane low power mode
     lteppp_send_at_cmd("AT!=\"setlpm airplane=1 enable=1\"", LTE_RX_TIMEOUT_MAX_MS);
 

--- a/esp32/lte/lteppp.h
+++ b/esp32/lte/lteppp.h
@@ -35,7 +35,8 @@
  DEFINE TYPES
  ******************************************************************************/
 typedef enum {
-    E_LTE_INIT = 0,
+    E_LTE_DEINIT = 0,
+    E_LTE_INIT,
     E_LTE_IDLE,
     E_LTE_ATTACHING,
     E_LTE_ATTACHED,

--- a/esp32/mods/modlte.c
+++ b/esp32/mods/modlte.c
@@ -355,12 +355,7 @@ static mp_obj_t lte_init_helper(lte_obj_t *self, const mp_arg_val_t *args) {
     if (!lte_push_at_command("AT", LTE_RX_TIMEOUT_MAX_MS)) {
         lte_pause_ppp();
     }
-    // disable PSM if enabled by default
-    lte_push_at_command("AT+CPSMS?", LTE_RX_TIMEOUT_MAX_MS);
-    if (!strstr(modlte_rsp.data, "+CPSMS: 0")) {
-        lte_push_at_command("AT+CPSMS=0", LTE_RX_TIMEOUT_MIN_MS);
-    }
-
+   
     lte_push_at_command("AT!=\"setlpm airplane=1 enable=1\"", LTE_RX_TIMEOUT_MIN_MS);
     lte_push_at_command("AT+CFUN?", LTE_RX_TIMEOUT_MIN_MS);
     if (strstr(modlte_rsp.data, "+CFUN: 0")) {
@@ -469,7 +464,7 @@ STATIC mp_obj_t lte_deinit(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t 
             }
             if (!args[0].u_bool || !args[2].u_bool) { /* backward compatibility for dettach method FIXME */
                 vTaskDelay(100);
-                lte_push_at_command("AT!=\"setlpm airplane=1 enable=1\"", LTE_RX_TIMEOUT_MAX_MS);
+                // lte_push_at_command("AT!=\"setlpm airplane=1 enable=1\"", LTE_RX_TIMEOUT_MAX_MS);
                 lteppp_deinit();
                 lte_obj.init = false;
                 vTaskDelay(100);


### PR DESCRIPTION
esp32/lteppp.h:	added new machine state E_LTE_DEINIT
esp32/lteppp.c:	removed disabling PSM
		lteppp_deinit() changes lte state to E_LTE_DEINIT
		lteppp_deinit() removed sending setlpm command before disabling UART. This caused the state machine to wait for a response from modem and timeout, resulting in a delay.
esp32/modlte.c:
		removed disabling PSM
		removed sending setlpm command before lteppp_deinit(). Sending commands to modem before disabling UART cause delays.