### PR TITLE
[WIP] Fix crash when pin ISR handler fires (i.e. LoRa TX done) during flash operation (i.e. ota_write() call)

### DIFF
--- a/esp32/lora/sx1272-board.c
+++ b/esp32/lora/sx1272-board.c
@@ -14,6 +14,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 */
 
 #include "board.h"
+#include "esp_attr.h"
 
 #if defined(LOPY) || defined (FIPY)
 
@@ -25,7 +26,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 /*!
  * Radio driver structure initialization
  */
-const struct Radio_s Radio =
+DRAM_ATTR const struct Radio_s Radio =
 {
     SX1272Init,
     SX1272GetStatus,

--- a/esp32/lora/sx1276-board.c
+++ b/esp32/lora/sx1276-board.c
@@ -14,6 +14,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 */
 
 #include "board.h"
+#include "esp_attr.h"
 
 #if defined(LOPY4)
 
@@ -24,7 +25,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 /*!
  * Radio driver structure initialization
  */
-const struct Radio_s Radio =
+DRAM_ATTR const struct Radio_s Radio =
 {
     SX1276Init,
     SX1276GetStatus,

--- a/lib/lora/mac/region/Region.c
+++ b/lib/lora/mac/region/Region.c
@@ -629,7 +629,7 @@ bool RegionIsActive( LoRaMacRegion_t region )
     }
 }
 
-PhyParam_t RegionGetPhyParam( LoRaMacRegion_t region, GetPhyParams_t* getPhy )
+IRAM_ATTR PhyParam_t RegionGetPhyParam( LoRaMacRegion_t region, GetPhyParams_t* getPhy )
 {
     PhyParam_t phyParam = { 0 };
     switch( region )

--- a/lib/lora/mac/region/RegionEU868.c
+++ b/lib/lora/mac/region/RegionEU868.c
@@ -184,7 +184,7 @@ static uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t
     return nbEnabledChannels;
 }
 
-PhyParam_t RegionEU868GetPhyParam( GetPhyParams_t* getPhy )
+IRAM_ATTR PhyParam_t RegionEU868GetPhyParam( GetPhyParams_t* getPhy )
 {
     PhyParam_t phyParam = { 0 };
 


### PR DESCRIPTION
I was seeing crashes with "Cache disabled but cached memory region accessed" as reason.
The coredump showed one of the threads being inside `spi_flash_op_block_func()`, while the thread that caused the crash was an ISR (with LoRa's `OnRadioTxDone` handler somewhere in the stacktrace).
The comment above spi_flash_op_block_func(), suggests that if an interrupt handler accesses PSRAM, it must not be part of the "IRAM" ISR handlers, so it will be disabld during flash ops.
This change will flag all ISR handlers for the Pin module as non-IRAM and thereby preventing the crashes.