### PR TITLE
Select ESP32 Wi-Fi protocol mode during WLAN init

### DIFF
--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -70,7 +70,9 @@ Methods
      - ``channel`` a number in the range 1-11. Only needed when mode is ``WLAN.AP``.
      - ``antenna`` selects between the internal and the external antenna. Can be either
        ``WLAN.INT_ANT`` or ``WLAN.EXT_ANT``.
+     - ``protocol_mode`` selects Wi-Fi protocol mode. Defaults to 802.11BGN (``WLAN.PROTOCOL_11B|WLAN.PROTOCOL_11G|WLAN.PROTOCOL_11N``). Here you can activate Espressif-patented long range mode with ``WLAN.PROTOCOL_LR``.
     - ``power_save`` enables or disables power save functions in STA mode.
+
 
    For example, you can do::
 
@@ -194,3 +196,10 @@ Constants
           WLAN.EXT_ANT
 
    selects the antenna type
+
+.. data:: WLAN.PROTOCOL_11B
+          WLAN.PROTOCOL_11G
+          WLAN.PROTOCOL_11N
+          WLAN.PROTOCOL_LR
+
+   selects the Wi-Fi protocol mode

--- a/esp32/mods/modwlan.h
+++ b/esp32/mods/modwlan.h
@@ -74,7 +74,7 @@ extern wlan_obj_t wlan_obj;
  DECLARE PUBLIC FUNCTIONS
  ******************************************************************************/
 extern void wlan_pre_init (void);
-extern void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, bool ssid_hidden);
+extern void wlan_setup (int32_t mode, const char *ssid, uint32_t auth, const char *key, uint32_t channel, uint32_t antenna, bool add_mac, bool ssid_hidden, uint32_t protocol_mode);
 extern void wlan_update(void);
 extern void wlan_get_mac (uint8_t *macAddress);
 extern void wlan_get_ip (uint32_t *ip);

--- a/esp32/mptask.c
+++ b/esp32/mptask.c
@@ -448,7 +448,8 @@ STATIC void mptask_enable_wifi_ap (void) {
 	uint8_t wifi_pwd[64];
 	config_get_wifi_pwd(wifi_pwd);
     wlan_setup (WIFI_MODE_AP, DEFAULT_AP_SSID, WIFI_AUTH_WPA2_PSK, DEFAULT_AP_PASSWORD ,
-                DEFAULT_AP_CHANNEL, ANTENNA_TYPE_INTERNAL, true, false);
+                DEFAULT_AP_CHANNEL, ANTENNA_TYPE_INTERNAL, true, false, WIFI_PROTOCOL_11B |
+                WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N );
     mod_network_register_nic(&wlan_obj);
 }
 


### PR DESCRIPTION
These patches allow selection of Wi-Fi protocol mode during wlan interface setup. If nothing is specified it falls back to default standard 802.11bgn modes.

To enable "Espressif specific" Long Range mode only just add `protocol_mode=WLAN.PROTOCOL_LR` (please refer to esp-idf Wi-FI Driver API guides for details).

E.g.
```
from network import WLAN
wlan = WLAN()
wlan.init(mode=WLAN.AP, ssid='test', antenna=WLAN.EXT_ANT, protocol_mode=PROTOCOL_LR)
```