### PR TITLE
Support modonewire from vanilla MicroPython

### DIFF
--- a/esp32/hal/esp32_mphal.h
+++ b/esp32/hal/esp32_mphal.h
@@ -35,4 +35,16 @@ void mp_hal_reset_safe_and_boot(bool reset);
 #define mp_hal_quiet_timing_exit(irq_state) MICROPY_END_ATOMIC_SECTION(irq_state)
 #define mp_hal_delay_us_fast(us) ets_delay_us(us)
 
+// C-level pin HAL
+#include "py/obj.h"
+#include "machpin.h"
+#define mp_hal_pin_obj_t mp_obj_t
+#define mp_hal_get_pin_obj(pin) (pin)
+#define mp_hal_pin_write(p, v) do { \
+		pin_obj_t *npin = pin_find(p); \
+		npin->value = v; \
+		pin_set_value(npin); \
+	} while (0)
+#define mp_hal_pin_read(p) pin_get_value(pin_find(p))
+
 #endif // _INCLUDED_MPHAL_H_

--- a/esp32/hal/esp32_mphal.h
+++ b/esp32/hal/esp32_mphal.h
@@ -30,4 +30,9 @@ void mp_hal_set_interrupt_char(int c);
 void mp_hal_set_reset_char(int c);
 void mp_hal_reset_safe_and_boot(bool reset);
 
+// https://github.com/micropython/micropython/blob/master/ports/esp32/mphalport.h
+#define mp_hal_quiet_timing_enter() MICROPY_BEGIN_ATOMIC_SECTION()
+#define mp_hal_quiet_timing_exit(irq_state) MICROPY_END_ATOMIC_SECTION(irq_state)
+#define mp_hal_delay_us_fast(us) ets_delay_us(us)
+
 #endif // _INCLUDED_MPHAL_H_

--- a/esp32/mpconfigport.h
+++ b/esp32/mpconfigport.h
@@ -191,6 +191,7 @@ extern const struct _mp_obj_module_t mp_module_uhashlib;
 extern const struct _mp_obj_module_t module_ucrypto;
 extern const struct _mp_obj_module_t mp_module_ussl;
 extern const struct _mp_obj_module_t mp_module_uqueue;
+extern const struct _mp_obj_module_t mp_module_onewire;
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_umachine),        (mp_obj_t)&machine_module },      \
@@ -206,6 +207,7 @@ extern const struct _mp_obj_module_t mp_module_uqueue;
     { MP_OBJ_NEW_QSTR(MP_QSTR_ussl),            (mp_obj_t)&mp_module_ussl },      \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uerrno),          (mp_obj_t)&mp_module_uerrno },    \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uqueue),          (mp_obj_t)&mp_module_uqueue },    \
+    { MP_OBJ_NEW_QSTR(MP_QSTR__onewire),        (mp_obj_t)&mp_module_onewire },   \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_machine),         (mp_obj_t)&machine_module },      \

--- a/py/py.mk
+++ b/py/py.mk
@@ -287,6 +287,7 @@ PY_EXTMOD_O_BASENAME = \
 	extmod/moduwebsocket.o \
 	extmod/modwebrepl.o \
 	extmod/modframebuf.o \
+	extmod/modonewire.o \
 	extmod/vfs.o \
 	extmod/vfs_reader.o \
 	extmod/vfs_posix.o \


### PR DESCRIPTION
Dear Pycom team,

first things first: Thank you so much for your hard work on bringing this hardware and software ecosystem to the world and congratulations to four years of Pycom by the way.

Coming from [1] and [2], we are interested to get more stable readings from some DS18B20 sensors we have attached to one of our FiPy devices by bringing in the 1-Wire driver from the upstream vanilla MicroPython [3].

In order to get started with that, we added this PR which enables the respective extmod at compile time and would be happy to get further support on that.

With kind regards,
Andreas.

[1] https://community.hiveeyes.org/t/untersuchung-und-verbesserung-des-timings-bei-der-ansteuerung-der-ds18b20-sensoren-unter-micropython/2309
[2] https://forum.pycom.io/topic/5330/onewire-py-problem
[3] https://docs.micropython.org/en/latest/esp32/quickref.html#onewire-driver
