### PR TITLE
Implemented configuration options for BLE security

### DIFF
--- a/docs/library/network.Bluetooth.rst
+++ b/docs/library/network.Bluetooth.rst
@@ -211,6 +211,36 @@ Methods
 
      bluetooth.set_advertisement(name="advert", manufacturer_data="lopy_v1")
 
+.. method:: bluetooth.set_pin(new_pin)
+
+    Sets a new pin code which clients can use to bond with this device. Only works when Bluetooth was initialized with ``secure=True``.
+
+    When the pin code is changed, all client bondings are removed, except for the currently connected client if any.
+
+    Arguments:
+
+       - ``pin`` is the 6 digit (0-9) pin code as an integer.
+
+    Example::
+
+        from network import Bluetooth
+
+        bluetooth = Bluetooth(secure=True, pin=123456)
+        bluetooth.set_advertisement(name='LoPy', service_uuid=b'1234567890123456')
+        bluetooth.advertise(True)
+
+        service = bluetooth.service(uuid=b'7890123456789012')
+        characteristic = service.characteristic(uuid=b'3456789012345678')
+
+        def char_cb(chr)
+            events = chr.events()
+            if events & Bluetooth.CHAR_WRITE_EVENT:
+                new_pin = int(chr.value())
+                print("Setting PIN to {}".format(new_pin))
+                bluetooth.set_pin(new_pin)
+
+        characteristic.callback(trigger=Bluetooth.CHAR_WRITE_EVENT, handler=char_cb)
+
 .. method:: bluetooth.advertise([Enable])
 
     Start or stop sending advertisements. The ``.set_advertisement()`` method must have been called prior to this one. ::
@@ -288,6 +318,17 @@ Constants
           Bluetooth.PROP_EXT_PROP
 
     Characteristic properties (bit values that can be combined)
+
+.. data:: PERM_READ
+          PERM_READ_ENCRYPTED
+          PERM_READ_ENC_MITM
+          PERM_WRITE
+          PERM_WRITE_ENCRYPTED
+          PERM_WRITE_ENC_MITM
+          PERM_WRITE_SIGNED
+          PERM_WRITE_SIGNED_MITM
+
+    Characteristic permissions (bit values that can be combined)
 
 .. data:: Bluetooth.CHAR_READ_EVENT
           Bluetooth.CHAR_WRITE_EVENT

--- a/esp32/mods/modbt.c
+++ b/esp32/mods/modbt.c
@@ -80,7 +80,6 @@
 #define MOD_BT_GATTS_CLOSE_EVT                              (0x0400)
 #define MOD_BT_NVS_NAMESPACE                                "BT_NVS"
 #define MOD_BT_HASH_SIZE                                    (20)
-#define MOD_BT_PIN_LENGTH                                   (6)
 
 /******************************************************************************
  DEFINE PRIVATE TYPES
@@ -103,6 +102,7 @@ typedef struct {
     bool                  advertising;
     bool                  controller_active;
     bool                  secure;
+    bool                  privacy;
 } bt_obj_t;
 
 typedef struct {
@@ -246,16 +246,6 @@ static esp_ble_adv_params_t bt_adv_params = {
     .channel_map        = ADV_CHNL_ALL,
     .adv_filter_policy  = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
 };
-
-static esp_ble_adv_params_t bt_adv_params_sec = {
-    .adv_int_min        = 0x100,
-    .adv_int_max        = 0x100,
-    .adv_type           = ADV_TYPE_IND,
-    .own_addr_type      = BLE_ADDR_TYPE_RANDOM,
-    .channel_map        = ADV_CHNL_ALL,
-    .adv_filter_policy  = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
-};
-
 
 static bool mod_bt_allow_resume_deinit;
 static uint16_t mod_bt_gatts_mtu_restore = 0;
@@ -416,11 +406,7 @@ void bt_resume(bool reconnect)
 
             /* See if there was an averstisment active before Sleep */
             if(bt_obj.advertising) {
-                if (!bt_obj.secure){
-                    esp_ble_gap_start_advertising(&bt_adv_params);
-                } else {
-                    esp_ble_gap_start_advertising(&bt_adv_params_sec);
-                }
+                esp_ble_gap_start_advertising(&bt_adv_params);
             }
         }
 
@@ -472,22 +458,6 @@ static void create_hash(uint32_t pin, uint8_t *h_value)
     mbedtls_sha1_free(&sha1_context);
 }
 
-static bool is_pin_valid(uint32_t pin)
-{
-    int digits = 0;
-
-    while(pin != 0)
-    {
-        digits++;
-        pin /= 10;
-    }
- 
-    if (digits != MOD_BT_PIN_LENGTH){
-       return false;
-    }
-
-    return true;
-}
 static bool pin_changed(uint32_t new_pin) 
 {   
      bool ret = false;
@@ -517,29 +487,42 @@ static bool pin_changed(uint32_t new_pin)
      return ret;
 }
 
-static void remove_all_bonded_devices(void)
+static void remove_bonded_devices(void)
 {
     int dev_num = esp_ble_get_bond_device_num();
 
     esp_ble_bond_dev_t *dev_list = heap_caps_malloc(sizeof(esp_ble_bond_dev_t) * dev_num, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     esp_ble_get_bond_device_list(&dev_num, dev_list);
     for (int i = 0; i < dev_num; i++) {
+        if (bt_obj.gatts_conn_id >= 0 && memcmp((void *) dev_list[i].bd_addr, (void *) bt_obj.client_bda, sizeof(esp_bd_addr_t)) == 0) {
+            continue;
+        }
         esp_ble_remove_bond_device(dev_list[i].bd_addr);
     }
 
     free(dev_list);
 }
 
-static void set_secure_parameters(uint32_t passKey){  
-
-    if (pin_changed(passKey)) {
-       remove_all_bonded_devices();
+static void set_pin(uint32_t new_pin)
+{
+    if (!bt_obj.secure) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Cannot set PIN when secure is not set"));
     }
-  
-    uint32_t passkey = passKey;
-    esp_ble_gap_set_security_param(ESP_BLE_SM_SET_STATIC_PASSKEY, &passkey, sizeof(uint32_t)); 
-    
-    esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
+
+    if (new_pin > 999999) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Only 6 digit (0-9) pins are allowed"));
+    }
+
+    if (pin_changed(new_pin)) {
+       remove_bonded_devices();
+    }
+
+    uint32_t passkey = new_pin;
+    esp_ble_gap_set_security_param(ESP_BLE_SM_SET_STATIC_PASSKEY, &passkey, sizeof(uint32_t));
+}
+
+static void set_secure_parameters(bool secure_connections) {
+    esp_ble_auth_req_t auth_req = secure_connections ? ESP_LE_AUTH_REQ_SC_MITM_BOND : ESP_LE_AUTH_BOND;
     esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(uint8_t));
 
     esp_ble_io_cap_t iocap = ESP_IO_CAP_OUT;
@@ -640,11 +623,6 @@ static void gap_events_handler (esp_gap_ble_cb_event_t event, esp_ble_gap_cb_par
         xQueueSend(xGattsQueue, (void *)&gatts_event, (TickType_t)0);
         break;
     }
-    case ESP_GAP_BLE_NC_REQ_EVT:
-    case ESP_GAP_BLE_PASSKEY_NOTIF_EVT: {
-         printf("BLE paring passkey : %d\n", param->ble_security.key_notif.passkey);
-         break;
-    }
     case ESP_GAP_BLE_SEC_REQ_EVT: {
         if (bt_obj.secure){
             esp_ble_gap_security_rsp(param->ble_security.ble_req.bd_addr, true);
@@ -691,7 +669,7 @@ static void gattc_events_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc
         status = p_data->reg.status;
         bt_obj.gattc_if = gattc_if;
         if (bt_obj.secure){
-           esp_ble_gap_config_local_privacy(true);
+           esp_ble_gap_config_local_privacy(bt_obj.privacy);
         }
         break;
     case ESP_GATTC_OPEN_EVT:
@@ -855,7 +833,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
     case ESP_GATTS_REG_EVT:
         bt_obj.gatts_if = gatts_if;
         if (bt_obj.secure){
-            esp_ble_gap_config_local_privacy(true);
+            esp_ble_gap_config_local_privacy(bt_obj.privacy);
         }
         break;
     case ESP_GATTS_READ_EVT: {
@@ -904,12 +882,6 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
                         char_obj->events |= MOD_BT_GATTS_SUBSCRIBE_EVT;
                         if (char_obj->trigger & MOD_BT_GATTS_SUBSCRIBE_EVT) {
                             mp_irq_queue_interrupt(gatts_char_callback_handler, char_obj);
-                        }
-
-                        if (value == 0x0001) {  // notifications enabled
-                            bt_gatts_char_obj_t *char_obj = (bt_gatts_char_obj_t *)attr_obj->parent;
-                            // the size of value[] needs to be less than MTU size
-                            esp_ble_gatts_send_indicate(gatts_if, param->write.conn_id, char_obj->attr_obj.handle, char_obj->attr_obj.value_len, char_obj->attr_obj.value, false);
                         }
                     }
                 }
@@ -963,20 +935,13 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
             if (bt_obj.trigger & MOD_BT_GATTS_CONN_EVT) {
                 mp_irq_queue_interrupt(bluetooth_callback_handler, (void *)&bt_obj);
             }
-            if (bt_obj.secure){
-                esp_ble_set_encryption(p->connect.remote_bda, ESP_BLE_SEC_ENCRYPT_MITM);
-            }
         }
         break;
     case ESP_GATTS_DISCONNECT_EVT:
         bt_obj.gatts_conn_id = -1;
         xEventGroupClearBits(bt_event_group, MOD_BT_GATTS_MTU_EVT);
         if (bt_obj.advertising) {
-            if (!bt_obj.secure){
-                esp_ble_gap_start_advertising(&bt_adv_params);
-            } else {
-                esp_ble_gap_start_advertising(&bt_adv_params_sec);
-            }
+            esp_ble_gap_start_advertising(&bt_adv_params);
         }
         bt_obj.events |= MOD_BT_GATTS_DISCONN_EVT;
         xEventGroupSetBits(bt_event_group, MOD_BT_GATTS_DISCONN_EVT);
@@ -1028,7 +993,7 @@ static mp_obj_t bt_init_helper(bt_obj_t *self, const mp_arg_val_t *args) {
         esp_ble_gatts_app_register(MOD_BT_SERVER_APP_ID);
 
         //set MTU
-        uint16_t mtu = args[5].u_int;
+        uint16_t mtu = args[7].u_int;
         if(mtu > BT_MTU_SIZE_MAX)
         {
             esp_ble_gatt_set_local_mtu(BT_MTU_SIZE_MAX);
@@ -1075,24 +1040,29 @@ static mp_obj_t bt_init_helper(bt_obj_t *self, const mp_arg_val_t *args) {
     if (args[3].u_bool){
         bt_obj.secure = true;
 
-        uint32_t passKey = args[4].u_int;
-        if (!is_pin_valid(passKey)){
-            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Only 6 digit (0-9) pins are allowed"));
-        } 
-        set_secure_parameters(passKey);
+        // modified default advertisement parameters for secure
+        bt_adv_params.adv_int_min = 0x100;
+        bt_adv_params.adv_int_max = 0x100;
+        bt_adv_params.own_addr_type = args[5].u_bool ? BLE_ADDR_TYPE_RANDOM : BLE_ADDR_TYPE_PUBLIC;
+
+        set_pin(args[4].u_int);
+        bt_obj.privacy = args[5].u_bool;
+        set_secure_parameters(args[6].u_bool);
     }
 
     return mp_const_none;
 }
 
 STATIC const mp_arg_t bt_init_args[] = {
-    { MP_QSTR_id,                             MP_ARG_INT,   {.u_int  = 0} },
-    { MP_QSTR_mode,         MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = E_BT_STACK_MODE_BLE} },
-    { MP_QSTR_antenna,      MP_ARG_KW_ONLY  | MP_ARG_OBJ,   {.u_obj  = MP_OBJ_NULL} },
-    { MP_QSTR_modem_sleep,  MP_ARG_KW_ONLY  | MP_ARG_OBJ,   {.u_obj  = MP_OBJ_NULL} },
-    { MP_QSTR_secure,       MP_ARG_KW_ONLY  | MP_ARG_BOOL,  {.u_bool = false} },
-    { MP_QSTR_pin,          MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = 123456} },
-    { MP_QSTR_mtu,          MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = BT_MTU_SIZE_MAX} },
+    { MP_QSTR_id,                                     MP_ARG_INT,   {.u_int  = 0} },
+    { MP_QSTR_mode,                 MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = E_BT_STACK_MODE_BLE} },
+    { MP_QSTR_antenna,              MP_ARG_KW_ONLY  | MP_ARG_OBJ,   {.u_obj  = MP_OBJ_NULL} },
+    { MP_QSTR_modem_sleep,          MP_ARG_KW_ONLY  | MP_ARG_OBJ,   {.u_obj  = MP_OBJ_NULL} },
+    { MP_QSTR_secure,               MP_ARG_KW_ONLY  | MP_ARG_BOOL,  {.u_bool = false} },
+    { MP_QSTR_pin,                  MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = 123456} },
+    { MP_QSTR_privacy,              MP_ARG_KW_ONLY  | MP_ARG_BOOL,  {.u_bool = true} },
+    { MP_QSTR_secure_connections,   MP_ARG_KW_ONLY  | MP_ARG_BOOL,  {.u_bool = true} },
+    { MP_QSTR_mtu,                  MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = BT_MTU_SIZE_MAX} },
 
 };
 STATIC mp_obj_t bt_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *all_args) {
@@ -1445,12 +1415,12 @@ static mp_obj_t modbt_connect(mp_obj_t addr)
 
 STATIC mp_obj_t bt_set_advertisement_params (mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_adv_int_min,              MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0x20} },
-        { MP_QSTR_adv_int_max,              MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0x40} },
-        { MP_QSTR_adv_type,                 MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ADV_TYPE_IND} },
-        { MP_QSTR_own_addr_type,            MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = BLE_ADDR_TYPE_PUBLIC} },
-        { MP_QSTR_channel_map,              MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ADV_CHNL_ALL} },
-        { MP_QSTR_adv_filter_policy,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY} },
+        { MP_QSTR_adv_int_min,              MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_adv_int_max,              MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_adv_type,                 MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_own_addr_type,            MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_channel_map,              MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_adv_filter_policy,        MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
  
     // parse args
@@ -1458,22 +1428,34 @@ STATIC mp_obj_t bt_set_advertisement_params (mp_uint_t n_args, const mp_obj_t *p
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(args), allowed_args, args);
  
     // adv_int_min
-    bt_adv_params.adv_int_min = (uint16_t)args[0].u_int;
+    if (args[0].u_obj != MP_OBJ_NULL) {
+        bt_adv_params.adv_int_min = (uint16_t) mp_obj_get_int(args[0].u_obj);
+    }
  
     // adv_int_max
-    bt_adv_params.adv_int_max = (uint16_t)args[1].u_int;
+    if (args[1].u_obj != MP_OBJ_NULL) {
+        bt_adv_params.adv_int_max = (uint16_t) mp_obj_get_int(args[1].u_obj);
+    }
 
     // adv_type
-    bt_adv_params.adv_type = (esp_ble_adv_type_t)args[2].u_int;
+    if (args[2].u_obj != MP_OBJ_NULL) {
+        bt_adv_params.adv_type = (esp_ble_adv_type_t) mp_obj_get_int(args[2].u_obj);
+    }
  
     // own_addr_type
-    bt_adv_params.own_addr_type = (esp_ble_addr_type_t)args[3].u_int;
+    if (args[3].u_obj != MP_OBJ_NULL) {
+        bt_adv_params.own_addr_type = (esp_ble_addr_type_t) mp_obj_get_int(args[3].u_obj);
+    }
  
     // channel_map
-    bt_adv_params.channel_map = (esp_ble_adv_channel_t)args[4].u_int;
+    if (args[4].u_obj != MP_OBJ_NULL) {
+        bt_adv_params.channel_map = (esp_ble_adv_channel_t) mp_obj_get_int(args[4].u_obj);
+    }
  
     // adv_filter_policy
-    bt_adv_params.adv_filter_policy = (esp_ble_adv_filter_t)args[5].u_int;
+    if (args[5].u_obj != MP_OBJ_NULL) {
+        bt_adv_params.adv_filter_policy = (esp_ble_adv_filter_t) mp_obj_get_int(args[5].u_obj);
+    }
 
     return mp_const_none;
 }
@@ -1606,15 +1588,18 @@ STATIC mp_obj_t bt_set_advertisement_raw(mp_obj_t self_in, mp_obj_t raw_data) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bt_set_advertisement_raw_obj, bt_set_advertisement_raw);
 
 
+STATIC mp_obj_t bt_set_pin(mp_obj_t self_in, mp_obj_t arg) {
+    set_pin(mp_obj_get_int(arg));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(bt_set_pin_obj, bt_set_pin);
+
+
 STATIC mp_obj_t bt_advertise(mp_obj_t self_in, mp_obj_t enable) {
     if (mp_obj_is_true(enable)) {
         // some sensible time to wait for the advertisement configuration to complete
         mp_hal_delay_ms(50);
-        if (!bt_obj.secure){
-            esp_ble_gap_start_advertising(&bt_adv_params);
-        } else {
-            esp_ble_gap_start_advertising(&bt_adv_params_sec);
-        }
+        esp_ble_gap_start_advertising(&bt_adv_params);
         bt_obj.advertising = true;
     } else {
         esp_ble_gap_stop_advertising();
@@ -2056,6 +2041,7 @@ STATIC const mp_map_elem_t bt_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_advertisement_params),(mp_obj_t)&bt_set_advertisement_params_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_advertisement),       (mp_obj_t)&bt_set_advertisement_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_advertisement_raw),   (mp_obj_t)&bt_set_advertisement_raw_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_set_pin),                 (mp_obj_t)&bt_set_pin_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_advertise),               (mp_obj_t)&bt_advertise_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_service),                 (mp_obj_t)&bt_service_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_callback),                (mp_obj_t)&bt_callback_obj },
@@ -2108,6 +2094,15 @@ STATIC const mp_map_elem_t bt_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_PROP_INDICATE),           MP_OBJ_NEW_SMALL_INT(ESP_GATT_CHAR_PROP_BIT_INDICATE) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_PROP_AUTH),               MP_OBJ_NEW_SMALL_INT(ESP_GATT_CHAR_PROP_BIT_AUTH) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_PROP_EXT_PROP),           MP_OBJ_NEW_SMALL_INT(ESP_GATT_CHAR_PROP_BIT_EXT_PROP) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_READ),               MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_READ) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_READ_ENCRYPTED),     MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_READ_ENCRYPTED) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_READ_ENC_MITM),      MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_READ_ENC_MITM) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_WRITE),              MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_WRITE) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_WRITE_ENCRYPTED),    MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_WRITE_ENCRYPTED) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_WRITE_ENC_MITM),     MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_WRITE_ENC_MITM) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_WRITE_SIGNED),       MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_WRITE_SIGNED) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PERM_WRITE_SIGNED_MITM),  MP_OBJ_NEW_SMALL_INT(ESP_GATT_PERM_WRITE_SIGNED_MITM) },
 
     // Defined at https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml
     { MP_OBJ_NEW_QSTR(MP_QSTR_CHAR_CONFIG_NOTIFY),      MP_OBJ_NEW_SMALL_INT(1 << 0) },


### PR DESCRIPTION
For our product we needed the ability to configure some additional options related to BLE security, which were available in the lower level Espressif stack but were not exposed though any MicroPython interface.

This pull request exposes a few new constants, parameters and methods for configuring these properties. Namely:

* A new method, `bluetooth.set_pin(new_pin)`, which can be used to configure a new pin at any time, not just during initialization of the Bluetooth object.
* A few constants `Bluetooth.PERM_*`, which can be used with the pre-existing `permissions` parameter of the `.characteristic()` method to configure the permissions that will be applied to a newly created characteristic. A secure connection will be established as soon as an encrypted characteristic is touched, meaning that by setting permissions it is possible to specify unencrypted characteristics which may be accessed without pairing. By default the permissions are set to encrypted if security is enabled, this was not changed and thus everything will function exactly the same as before unless a developer chooses to specifically set the parameter.
* Two new named parameters for the `Bluetooth` initialization, namely `privacy=True` and `secure_connections=True`,  which allow selectively disabling certain security features which impact how phones and other devices behave when interacting with the Pycom board. Again, by default these remain enabled and unless changed explicitly everything will function the same as before.
* The existing `bluetooth.set_advertisement_params()` method would not work when BLE security was enabled. This has been resolved so that now it is possible to configure advertisement parameters as expected in all cases.
* The Python interface would not allow pin codes to start with a `0` digit, while it is supported and allowed by the Bluetooth spec. In all our BLE products the default pin code is `000000`, and for uniformity we want to use that here as well. This pull request resolves this so now pin codes are allowed to start with a zero.

The changes were verified with a number of phones, and we also double-checked by inspecting the raw BLE traffic with a sniffer.

Documentation has been updated to describe the new `set_pin()` method and permission constants.