### PR TITLE
mods/machuart.c: Support the UART inverted mode

### DIFF
--- a/esp32/mods/machuart.c
+++ b/esp32/mods/machuart.c
@@ -597,9 +597,9 @@ STATIC mp_obj_t mach_uart_sendbreak(mp_uint_t n_args, const mp_obj_t *pos_args, 
             gpio_matrix_out(pin->pin_number, pin->af_out, false, false);
         }
 
-        WRITE_PERI_REG(UART_CONF0_REG(self->uart_id), READ_PERI_REG(UART_CONF0_REG(self->uart_id)) | UART_TXD_INV);
+        WRITE_PERI_REG(UART_CONF0_REG(self->uart_id), READ_PERI_REG(UART_CONF0_REG(self->uart_id)) ^ UART_TXD_INV);
         ets_delay_us((delay > 0) ? delay : 1);
-        WRITE_PERI_REG(UART_CONF0_REG(self->uart_id), READ_PERI_REG(UART_CONF0_REG(self->uart_id)) & (~UART_TXD_INV));
+        WRITE_PERI_REG(UART_CONF0_REG(self->uart_id), READ_PERI_REG(UART_CONF0_REG(self->uart_id)) ^ UART_TXD_INV);
 
         if (self->n_pins == 1) {
             // make it an input again


### PR DESCRIPTION
Inverted mode can be set by a keyword argument to init or the
constructor, using invert=<option|option...>
options are: INV_RX, INV_TX, INV_RTS and INV_CTS

Example:
from machine import UART
uart=UART(1, 9600, invert=UART.INV_TX | UART.INV_RX)