### PR TITLE
Fixing crash when make_new is called with zero arguments

### DIFF
--- a/esp32/mods/machuart.c
+++ b/esp32/mods/machuart.c
@@ -451,7 +451,7 @@ error:
 }
 
 STATIC const mp_arg_t mach_uart_init_args[] = {
-    { MP_QSTR_id,                              MP_ARG_OBJ,  {.u_obj = MP_OBJ_NULL} },
+    { MP_QSTR_id,                              MP_ARG_INT,  {.u_int = MACH_UART_0} },
     { MP_QSTR_baudrate,                        MP_ARG_INT,  {.u_int = 9600} },
     { MP_QSTR_bits,                            MP_ARG_INT,  {.u_int = 8} },
     { MP_QSTR_parity,                          MP_ARG_OBJ,  {.u_obj = mp_const_none} },
@@ -468,7 +468,7 @@ STATIC mp_obj_t mach_uart_make_new(const mp_obj_type_t *type, mp_uint_t n_args, 
     mp_arg_parse_all(n_args, all_args, &kw_args, MP_ARRAY_SIZE(args), mach_uart_init_args, args);
 
     // work out the uart id
-    uint uart_id = mp_obj_get_int(args[0].u_obj);
+    uint uart_id = args[0].u_int;
 
 #if defined(GPY) || defined(FIPY)
     if (uart_id > MACH_UART_1) {

--- a/esp32/mods/modbt.c
+++ b/esp32/mods/modbt.c
@@ -883,6 +883,12 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
                         if (char_obj->trigger & MOD_BT_GATTS_SUBSCRIBE_EVT) {
                             mp_irq_queue_interrupt(gatts_char_callback_handler, char_obj);
                         }
+
+                        if (value == 0x0001) {  // notifications enabled
+                            bt_gatts_char_obj_t *char_obj = (bt_gatts_char_obj_t *)attr_obj->parent;
+                            // the size of value[] needs to be less than MTU size
+                            esp_ble_gatts_send_indicate(gatts_if, param->write.conn_id, char_obj->attr_obj.handle, char_obj->attr_obj.value_len, char_obj->attr_obj.value, false);
+                        }
                     }
                 }
                 esp_ble_gatts_send_response(gatts_if, p->write.conn_id, p->write.trans_id, ESP_GATT_OK, NULL);

--- a/esp32/mods/modbt.c
+++ b/esp32/mods/modbt.c
@@ -487,19 +487,17 @@ static bool pin_changed(uint32_t new_pin)
      return ret;
 }
 
-static void remove_bonded_devices(void)
+static void remove_all_bonded_devices(void)
 {
     int dev_num = esp_ble_get_bond_device_num();
 
     esp_ble_bond_dev_t *dev_list = heap_caps_malloc(sizeof(esp_ble_bond_dev_t) * dev_num, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     esp_ble_get_bond_device_list(&dev_num, dev_list);
     for (int i = 0; i < dev_num; i++) {
-        if (bt_obj.gatts_conn_id >= 0 && memcmp((void *) dev_list[i].bd_addr, (void *) bt_obj.client_bda, sizeof(esp_bd_addr_t)) == 0) {
-            continue;
-        }
+    	close_connection(dev_list[i].bd_addr);
         esp_ble_remove_bond_device(dev_list[i].bd_addr);
     }
-
+    esp_ble_gap_start_advertising(&bt_adv_params);
     free(dev_list);
 }
 
@@ -514,7 +512,7 @@ static void set_pin(uint32_t new_pin)
     }
 
     if (pin_changed(new_pin)) {
-       remove_bonded_devices();
+       remove_all_bonded_devices();
     }
 
     uint32_t passkey = new_pin;

--- a/esp32/mods/modbt.c
+++ b/esp32/mods/modbt.c
@@ -102,7 +102,6 @@ typedef struct {
     bool                  advertising;
     bool                  controller_active;
     bool                  secure;
-    bool                  secure_connections;
     bool                  privacy;
 } bt_obj_t;
 
@@ -504,6 +503,24 @@ static void remove_bonded_devices(void)
     free(dev_list);
 }
 
+static void set_pin(uint32_t new_pin)
+{
+    if (!bt_obj.secure) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Cannot set PIN when secure is not set"));
+    }
+
+    if (new_pin > 999999) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Only 6 digit (0-9) pins are allowed"));
+    }
+
+    if (pin_changed(new_pin)) {
+       remove_bonded_devices();
+    }
+
+    uint32_t passkey = new_pin;
+    esp_ble_gap_set_security_param(ESP_BLE_SM_SET_STATIC_PASSKEY, &passkey, sizeof(uint32_t));
+}
+
 static void set_secure_parameters(bool secure_connections) {
     esp_ble_auth_req_t auth_req = secure_connections ? ESP_LE_AUTH_REQ_SC_MITM_BOND : ESP_LE_AUTH_BOND;
     esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(uint8_t));
@@ -522,22 +539,6 @@ static void set_secure_parameters(bool secure_connections) {
 
     uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
     esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, sizeof(uint8_t));
-}
-
-static void set_pin(uint32_t new_pin)
-{
-    if (new_pin > 999999) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Only 1-6 digit (0-9) pins are allowed"));
-    }
-
-    if (pin_changed(new_pin)) {
-       remove_bonded_devices();
-    }
-
-    uint32_t passkey = new_pin;
-    esp_ble_gap_set_security_param(ESP_BLE_SM_SET_STATIC_PASSKEY, &passkey, sizeof(uint32_t));
-    bt_obj.secure = true;
-    set_secure_parameters(bt_obj.secure_connections);
 }
 
 static void close_connection (int32_t conn_id) {
@@ -992,7 +993,7 @@ static mp_obj_t bt_init_helper(bt_obj_t *self, const mp_arg_val_t *args) {
         esp_ble_gatts_app_register(MOD_BT_SERVER_APP_ID);
 
         //set MTU
-        uint16_t mtu = args[6].u_int;
+        uint16_t mtu = args[7].u_int;
         if(mtu > BT_MTU_SIZE_MAX)
         {
             esp_ble_gatt_set_local_mtu(BT_MTU_SIZE_MAX);
@@ -1036,21 +1037,17 @@ static mp_obj_t bt_init_helper(bt_obj_t *self, const mp_arg_val_t *args) {
         }
     }
 
-    bt_obj.secure_connections = args[5].u_bool;
-
-    if (args[3].u_obj != MP_OBJ_NULL){
+    if (args[3].u_bool){
         bt_obj.secure = true;
 
         // modified default advertisement parameters for secure
         bt_adv_params.adv_int_min = 0x100;
         bt_adv_params.adv_int_max = 0x100;
-        bt_adv_params.own_addr_type = args[4].u_bool ? BLE_ADDR_TYPE_RANDOM : BLE_ADDR_TYPE_PUBLIC;
+        bt_adv_params.own_addr_type = args[5].u_bool ? BLE_ADDR_TYPE_RANDOM : BLE_ADDR_TYPE_PUBLIC;
 
-        set_pin(mp_obj_get_int(args[3].u_obj));
-        bt_obj.privacy = args[4].u_bool;
-        set_secure_parameters(bt_obj.secure_connections);
-    } else {
-    	bt_obj.secure = false;
+        set_pin(args[4].u_int);
+        bt_obj.privacy = args[5].u_bool;
+        set_secure_parameters(args[6].u_bool);
     }
 
     return mp_const_none;
@@ -1061,7 +1058,8 @@ STATIC const mp_arg_t bt_init_args[] = {
     { MP_QSTR_mode,                 MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = E_BT_STACK_MODE_BLE} },
     { MP_QSTR_antenna,              MP_ARG_KW_ONLY  | MP_ARG_OBJ,   {.u_obj  = MP_OBJ_NULL} },
     { MP_QSTR_modem_sleep,          MP_ARG_KW_ONLY  | MP_ARG_OBJ,   {.u_obj  = MP_OBJ_NULL} },
-	{ MP_QSTR_pin,                  MP_ARG_KW_ONLY  | MP_ARG_OBJ,   {.u_obj  = MP_OBJ_NULL} },
+    { MP_QSTR_secure,               MP_ARG_KW_ONLY  | MP_ARG_BOOL,  {.u_bool = false} },
+    { MP_QSTR_pin,                  MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = 123456} },
     { MP_QSTR_privacy,              MP_ARG_KW_ONLY  | MP_ARG_BOOL,  {.u_bool = true} },
     { MP_QSTR_secure_connections,   MP_ARG_KW_ONLY  | MP_ARG_BOOL,  {.u_bool = true} },
     { MP_QSTR_mtu,                  MP_ARG_KW_ONLY  | MP_ARG_INT,   {.u_int  = BT_MTU_SIZE_MAX} },
@@ -1084,7 +1082,7 @@ STATIC mp_obj_t bt_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp_uint
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, mpexception_os_resource_not_avaliable));
     }
 
-    if (args[4].u_obj != MP_OBJ_NULL) {
+    if (args[4].u_bool) {
        if (heap_caps_get_free_size(MALLOC_CAP_SPIRAM) == 0) {
           nlr_raise(mp_obj_new_exception_msg(&mp_type_MemoryError,"Secure BLE not available for 512K RAM devices"));
        }

--- a/esp32/mods/modbt.c
+++ b/esp32/mods/modbt.c
@@ -495,7 +495,7 @@ static void remove_all_bonded_devices(void)
     esp_ble_bond_dev_t *dev_list = heap_caps_malloc(sizeof(esp_ble_bond_dev_t) * dev_num, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     esp_ble_get_bond_device_list(&dev_num, dev_list);
     for (int i = 0; i < dev_num; i++) {
-    	close_connection(dev_list[i].bd_addr);
+    	//close_connection(dev_list[i].bd_addr);
         esp_ble_remove_bond_device(dev_list[i].bd_addr);
     }
     esp_ble_gap_start_advertising(&bt_adv_params);

--- a/esp32/mods/modbt.c
+++ b/esp32/mods/modbt.c
@@ -495,7 +495,6 @@ static void remove_all_bonded_devices(void)
     esp_ble_bond_dev_t *dev_list = heap_caps_malloc(sizeof(esp_ble_bond_dev_t) * dev_num, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     esp_ble_get_bond_device_list(&dev_num, dev_list);
     for (int i = 0; i < dev_num; i++) {
-    	//close_connection(dev_list[i].bd_addr);
         esp_ble_remove_bond_device(dev_list[i].bd_addr);
     }
     esp_ble_gap_start_advertising(&bt_adv_params);


### PR DESCRIPTION
When class is instantiated on python side with zero arguments `uart = UART(0)`, crash is experienced. Crash is caused by `mp_obj_get_int()` function on `MP_OBJ_NULL`. If there is no strong reason using `MP_ARG_OBJ` as default value of ID, it seems reasonable to use `MP_ARG_INT` instead, with the intended `MACH_UART_0` default value.

In case of keeping the original MP_ARG_OBJ definition of id, an other workaround could be:

`uint uart_id;`
`if(args[0].u_obj == MP_OBJ_NULL) {`
`uart_id = MACH_UART_0;`
`} else {`
`uart_id = mp_obj_get_int(args[0].u_obj);`
`}`

Initiating UART with `id = 0` (which is the default value) results a 'freeze-like' behaviour in REPL (we 'lost connection' to the board from terminal). In frozen module, terminal is started during boot on `id = 0`, `baudrate = 115200`, so this is the intended behaviour, but default UART id could be also `id = 1` (just a tip).