### PR TITLE
Added interface to save and resume SSL sessions

### DIFF
--- a/docs/library/ussl.rst
+++ b/docs/library/ussl.rst
@@ -114,6 +114,21 @@ network sockets, both client-side and server-side.
 
        SSL sockets inherit all methods and from the standard sockets, see the :mod:`usocket` module.
 
+    .. function:: ssl.save_session(sock)
+
+       Takes an instance sock of ssl.SSLSocket, and returns an instance of ssl.SSLSession representing saved session data from the socket, which can be used to resume a SSL session later. Example::
+
+          import socket
+          import ssl
+          addr = socket.getaddrinfo('www.google.com', 443)[0][-1]
+          sock_one = ssl.wrap_socket(socket.socket())
+          sock_one.connect(addr) # performs a full ssl handshake
+          session = ssl.save_session(sock_one)
+          sock_one.close()
+          sock_one = None
+          sock_two = ssl.wrap_socket(socket.socket(), saved_session=session)
+          sock_two.connect(addr) # resumes using saved session, resulting in a faster handshake
+
     Exceptions
     ----------
 

--- a/esp32/mods/modussl.c
+++ b/esp32/mods/modussl.c
@@ -47,6 +47,25 @@ static char *mod_ssl_read_file (const char *file_path, vstr_t *vstr);
 /******************************************************************************
  DECLARE PRIVATE DATA
  ******************************************************************************/
+// tiny object for storing ssl sessions
+STATIC mp_obj_t ssl_session_free(mp_obj_t self_in) {
+    mp_obj_ssl_session_t *self = self_in;
+    mbedtls_ssl_session_free(&self->saved_session);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(ssl_session_free_obj, ssl_session_free);
+
+STATIC const mp_map_elem_t ssl_session_locals_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___del__),             (mp_obj_t)&ssl_session_free_obj },
+};
+STATIC MP_DEFINE_CONST_DICT(ssl_session_locals_dict, ssl_session_locals_dict_table);
+
+static const mp_obj_type_t mod_ssl_session_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_SSLSession,
+    .locals_dict = (mp_obj_t)&ssl_session_locals_dict,
+};
+
 // ssl sockets inherit from normal socket, so we take its
 // locals and stream methods
 STATIC const mp_obj_type_t ssl_socket_type = {
@@ -58,7 +77,7 @@ STATIC const mp_obj_type_t ssl_socket_type = {
     .locals_dict = (mp_obj_t)&socket_locals_dict,
 };
 
-static int32_t mod_ssl_setup_socket (mp_obj_ssl_socket_t *ssl_sock, const char *host_name,
+static int32_t mod_ssl_setup_socket (mp_obj_ssl_socket_t *ssl_sock, const mbedtls_ssl_session *saved_session, const char *host_name,
                                      const char *ca_cert_path, const char *client_cert_path,
                                      const char *key_path, uint32_t ssl_verify, uint32_t client_or_server) {
 
@@ -138,6 +157,12 @@ static int32_t mod_ssl_setup_socket (mp_obj_ssl_socket_t *ssl_sock, const char *
     if ((ret = mbedtls_ssl_setup(&ssl_sock->ssl, &ssl_sock->conf)) != 0) {
         // printf("mbedtls_ssl_setup returned -0x%x\n\n", -ret);
         return ret;
+    }
+    if (saved_session != NULL) {
+        if ((ret = mbedtls_ssl_set_session(&ssl_sock->ssl, saved_session)) != 0) {
+            // printf("mbedtls_ssl_set_session returned -0x%x\n\n", -ret);
+            return ret;
+        }
     }
 
     if (host_name) {
@@ -276,6 +301,7 @@ STATIC mp_obj_t mod_ssl_wrap_socket(mp_uint_t n_args, const mp_obj_t *pos_args, 
         { MP_QSTR_ssl_version,                  MP_ARG_KW_ONLY  | MP_ARG_INT,  {.u_int = 0} },
         { MP_QSTR_ca_certs,                     MP_ARG_KW_ONLY  | MP_ARG_OBJ,  {.u_obj = mp_const_none} },
         { MP_QSTR_server_hostname,              MP_ARG_KW_ONLY  | MP_ARG_OBJ,  {.u_obj = mp_const_none} },
+        { MP_QSTR_saved_session,                MP_ARG_KW_ONLY  | MP_ARG_OBJ,  {.u_obj = mp_const_none} },
         { MP_QSTR_timeout,                      MP_ARG_KW_ONLY  | MP_ARG_OBJ,  {.u_obj = mp_const_none} },
     };
 
@@ -304,6 +330,9 @@ STATIC mp_obj_t mod_ssl_wrap_socket(mp_uint_t n_args, const mp_obj_t *pos_args, 
         goto arg_error;
     }
 
+    // Retrieve previously saved session
+    const mbedtls_ssl_session *saved_session  = (args[8].u_obj == mp_const_none) ? NULL : &((mp_obj_ssl_session_t *)args[8].u_obj)->saved_session;
+
     // create the ssl socket
     mp_obj_ssl_socket_t *ssl_sock = m_new_obj_with_finaliser(mp_obj_ssl_socket_t);
     // ssl sockets inherit all properties from the original socket
@@ -312,18 +341,18 @@ STATIC mp_obj_t mod_ssl_wrap_socket(mp_uint_t n_args, const mp_obj_t *pos_args, 
     ssl_sock->o_sock = args[0].u_obj;       // this is needed so that the GC doesnt collect the socket
 
     //Read timeout
-    if(args[8].u_obj == mp_const_none)
+    if(args[9].u_obj == mp_const_none)
     {
         ssl_sock->read_timeout = DEFAULT_SSL_READ_TIMEOUT;
     }
     else
     {
-        ssl_sock->read_timeout = mp_obj_get_int(args[8].u_obj);
+        ssl_sock->read_timeout = mp_obj_get_int(args[9].u_obj);
     }
 
     MP_THREAD_GIL_EXIT();
 
-    _error = mod_ssl_setup_socket(ssl_sock, host_name, cafile_path, certfile_path, keyfile_path,
+    _error = mod_ssl_setup_socket(ssl_sock, saved_session, host_name, cafile_path, certfile_path, keyfile_path,
                                   verify_type, server_side ? MBEDTLS_SSL_IS_SERVER : MBEDTLS_SSL_IS_CLIENT);
 
     MP_THREAD_GIL_ENTER();
@@ -339,9 +368,42 @@ arg_error:
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ssl_wrap_socket_obj, 0, mod_ssl_wrap_socket);
 
+STATIC mp_obj_t mod_ssl_save_session(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    STATIC const mp_arg_t allowed_args[] = {
+        { MP_QSTR_ssl_sock,     MP_ARG_REQUIRED | MP_ARG_OBJ, },
+    };
+
+    int32_t _error;
+
+    // parse arguments
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    mp_obj_ssl_socket_t *ssl_sock = args[0].u_obj;
+
+    // Create the SSL session obj
+    mp_obj_ssl_session_t *ssl_session = m_new_obj_with_finaliser(mp_obj_ssl_session_t);
+    ssl_session->base.type = &mod_ssl_session_type;
+    memset(&ssl_session->saved_session, 0, sizeof(mbedtls_ssl_session));
+
+    MP_THREAD_GIL_EXIT();
+
+    _error = mbedtls_ssl_get_session(&ssl_sock->ssl, &ssl_session->saved_session);
+
+    MP_THREAD_GIL_ENTER();
+
+    if (_error) {
+        mp_raise_OSError(_error);
+    }
+
+    return ssl_session;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ssl_save_session_obj, 0, mod_ssl_save_session);
+
 STATIC const mp_map_elem_t mp_module_ussl_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__),            MP_OBJ_NEW_QSTR(MP_QSTR_ussl) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_wrap_socket),         (mp_obj_t)&mod_ssl_wrap_socket_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_save_session),        (mp_obj_t)&mod_ssl_save_session_obj },
 
     // class exceptions
     { MP_OBJ_NEW_QSTR(MP_QSTR_SSLError),            (mp_obj_t)&mp_type_OSError },
@@ -365,4 +427,3 @@ const mp_obj_module_t mp_module_ussl = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ussl_globals,
 };
-

--- a/esp32/mods/modussl.h
+++ b/esp32/mods/modussl.h
@@ -45,4 +45,9 @@ typedef struct _mp_obj_ssl_socket_t {
     uint8_t read_timeout;
 } mp_obj_ssl_socket_t;
 
+typedef struct _mp_obj_ssl_session_t {
+    mp_obj_base_t base;
+    mbedtls_ssl_session saved_session;
+} mp_obj_ssl_session_t;
+
 #endif /* MODUSSL_H_ */


### PR DESCRIPTION
In many parts of the world, mobile data is both expensive and slow, and thus we are interested in reducing our mobile data use. One area where we might improve is in our use of TLS. Our product uses TLS using the built-in `ussl` module, and the overhead of TLS on these connections is quite considerable.

Performing a full TLS handshake is expensive, both in time (two round-trips) and in data (full certificates are transmitted). The first time we connect to a server there is not really a way around this. However for subsequent connections we can instead perform a TLS resumption, reducing both the number of round-trips and amount of data transferred.

TLS resumption is supported by the mbedtls library, but had no MicroPython interface exposed to actually use it. This pull requests implements a new function, `ussl.save_session(sock)`, which can be used to make a copy of the session data of an already established TLS connection. The object which it returns holds the necessary data to resume a TLS connection later on, independent of the SSLSocket (which may be closed and fully disposed). To use it a new optional parameter is added to the `ussl.wrap_socket()` function which takes a saved session object and uses it to resume a TLS connection.

(Note: We opted for manual saving an session object as opposed to an automatic caching mechanism. Our approach gives the user more control over which sessions are persisted and doesn't require a complexer interface to manage the cache.)

A quick test shows vast improvements in both time (from 0.8266 to 0.0987s ≈ 88% faster) and data use (upload from 1078 bytes to 1069 bytes, download from 4001 to 634 bytes, total ≈ 66% smaller) for resumed sessions (averages, including TCP overhead).

Unless explicitly used, these additions do not impact any existing code and are fully backwards compatible. Documentation has been updated with an example of the new functionality.
