### PR TITLE
esp32/lteppp: Don't send CR each time when invoking "lteppp_send_at_cmd"

### DIFF
--- a/esp32/lte/lteppp.c
+++ b/esp32/lte/lteppp.c
@@ -658,7 +658,7 @@ static bool lteppp_send_at_cmd_exp (const char *cmd, uint32_t timeout, const cha
         // uart_read_bytes(LTE_UART_ID, (uint8_t *)tmp_buf, sizeof(tmp_buf), 5 / portTICK_RATE_MS);
         // then send the command
         uart_write_bytes(LTE_UART_ID, cmd, cmd_len);
-        if (strcmp(cmd, "+++")) {
+        if (!strcmp(cmd, "+++")) {
             uart_write_bytes(LTE_UART_ID, "\r", 1);
         }
         uart_wait_tx_done(LTE_UART_ID, LTE_TRX_WAIT_MS(cmd_len) / portTICK_RATE_MS);


### PR DESCRIPTION
@LaRox11 found this when trying to send AT+CSIM commands longer than 500 bytes to the modem. As the buffer behind this method is only 127 bytes long and the strcmp was evaluated erroneous, this stopped users sending longer commands in several chunks.

See also #411.