### PR TITLE
Fix core panics: Don't use m_malloc and gc_malloc unintended

### DIFF
--- a/esp32/ftp/ftp.c
+++ b/esp32/ftp/ftp.c
@@ -338,7 +338,7 @@ STATIC FRESULT f_readdir_helper(ftp_dir_t *dp, ftp_fileinfo_t *fno ) {
                 if(length_of_relative_path > 1) {
                     path_length++;
                 }
-                char* file_relative_path = m_malloc(path_length);
+                char* file_relative_path = pvPortMalloc(path_length);
 
                 // Copy the current working directory (relative path)
                 memcpy(file_relative_path, path_relative, length_of_relative_path);
@@ -359,7 +359,7 @@ STATIC FRESULT f_readdir_helper(ftp_dir_t *dp, ftp_fileinfo_t *fno ) {
                     fno->u.fpinfo_lfs.timestamp.ftime = 0;
                 }
 
-                m_free(file_relative_path);
+                vPortFree(file_relative_path);
             }
 
         xSemaphoreGive(littlefs->mutex);

--- a/esp32/littlefs/lfs_util.h
+++ b/esp32/littlefs/lfs_util.h
@@ -21,7 +21,6 @@
 
 #include "py/mpconfig.h"
 #include "py/misc.h"
-#include "py/gc.h"
 
 // System includes
 #include <stdint.h>
@@ -204,7 +203,7 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 // Note, memory must be 64-bit aligned
 static inline void *lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
-    return gc_alloc(size, false);
+    return pvPortMalloc(size);
 #else
     return NULL;
 #endif
@@ -213,7 +212,7 @@ static inline void *lfs_malloc(size_t size) {
 // Deallocate memory, only used if buffers are not provided to littlefs
 static inline void lfs_free(void *p) {
 #ifndef LFS_NO_MALLOC
-    m_free(p);
+    vPortFree(p);
 #endif
 }
 

--- a/esp32/littlefs/vfs_littlefs_file.c
+++ b/esp32/littlefs/vfs_littlefs_file.c
@@ -171,7 +171,7 @@ STATIC mp_obj_t file_open(fs_user_mount_t *vfs, const mp_obj_type_t *type, mp_ar
         int res = littlefs_open_common_helper(&vfs->fs.littlefs.lfs, fname, &o->fp, mode, &o->cfg, &o->timestamp_update);
     xSemaphoreGive(vfs->fs.littlefs.mutex);
 
-    m_free((void*)fname);
+    vPortFree((void*)fname);
     if (res < LFS_ERR_OK) {
         m_del_obj(pyb_file_obj_t, o);
         mp_raise_OSError(littleFsErrorToErrno(res));

--- a/esp32/mods/machpwm.c
+++ b/esp32/mods/machpwm.c
@@ -103,6 +103,7 @@ STATIC mp_obj_t mach_pwm_channel_make_new(mp_uint_t n_args, const mp_obj_t *pos_
 
     // get the correct pwm timer instance
     if (pwm->mach_pwm_channel_obj_t[pwm_channel_id] == NULL) {
+        // FIXME: This should be reviewed. "gc_alloc" might not be appropriate here.
         pwm->mach_pwm_channel_obj_t[pwm_channel_id] = gc_alloc(sizeof(mach_pwm_channel_obj_t), false);
     }
     mach_pwm_channel_obj_t *self = pwm->mach_pwm_channel_obj_t[pwm_channel_id];
@@ -191,6 +192,7 @@ STATIC mp_obj_t mach_pwm_timer_make_new(const mp_obj_type_t *type, mp_uint_t n_a
 
     // get the correct pwm timer instance or create a new one
     if (MP_STATE_PORT(mach_pwm_timer_obj[pwm_timer_id]) == NULL) {
+        // FIXME: This should be reviewed. "gc_alloc" might not be appropriate here.
         MP_STATE_PORT(mach_pwm_timer_obj[pwm_timer_id]) = gc_alloc(sizeof(mach_pwm_timer_obj_t), false);
         memset(((mach_pwm_timer_obj_t *) MP_STATE_PORT(mach_pwm_timer_obj[pwm_timer_id]))->mach_pwm_channel_obj_t,
                0, sizeof(((mach_pwm_timer_obj_t *) MP_STATE_PORT(mach_pwm_timer_obj[pwm_timer_id]))->mach_pwm_channel_obj_t));

--- a/esp32/mods/machrmt.c
+++ b/esp32/mods/machrmt.c
@@ -365,7 +365,7 @@ STATIC mp_obj_t mach_rmt_pulses_send(mp_uint_t n_args, const mp_obj_t *pos_args,
 
     /* An rmt_item32_t can contain 2 bits, calculate the number of the necessary objects needed to store the input data */
     mp_uint_t items_to_send_count = (data_length / 2) + (data_length % 2);
-    rmt_item32_t* items_to_send = (rmt_item32_t*)m_malloc(items_to_send_count * sizeof(rmt_item32_t));
+    rmt_item32_t* items_to_send = (rmt_item32_t*)pvPortMalloc(items_to_send_count * sizeof(rmt_item32_t));
     for(mp_uint_t i = 0, j = 0; i < items_to_send_count; i++, j++) {
 
         items_to_send[i].level0 = mp_obj_get_int(data_ptr[j]);
@@ -396,7 +396,7 @@ STATIC mp_obj_t mach_rmt_pulses_send(mp_uint_t n_args, const mp_obj_t *pos_args,
     esp_err_t retval = rmt_write_items(self->config.channel, items_to_send, items_to_send_count, wait_tx_done);
     MP_THREAD_GIL_ENTER();
 
-    m_free(items_to_send);
+    vPortFree(items_to_send);
 
     if (retval != ESP_OK) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Could not send data!"));

--- a/esp32/mods/machtimer_alarm.c
+++ b/esp32/mods/machtimer_alarm.c
@@ -8,7 +8,6 @@
 #include "py/mpconfig.h"
 #include "py/nlr.h"
 #include "py/runtime.h"
-#include "py/gc.h"
 #include "py/mperrno.h"
 #include "util/mpirq.h"
 
@@ -56,7 +55,7 @@ void mach_timer_alarm_preinit(void) {
 
 void mach_timer_alarm_init_heap(void) {
     alarm_heap.count = 0;
-    MP_STATE_PORT(mp_alarm_heap) = gc_alloc(ALARM_HEAP_MAX_ELEMENTS * sizeof(mp_obj_alarm_t *), false);
+    MP_STATE_PORT(mp_alarm_heap) = pvPortMalloc(ALARM_HEAP_MAX_ELEMENTS * sizeof(mp_obj_alarm_t *));
     alarm_heap.data = MP_STATE_PORT(mp_alarm_heap);
     if (alarm_heap.data == NULL) {
         mp_printf(&mp_plat_print, "FATAL ERROR: not enough memory for the alarms heap\n");

--- a/esp32/mods/modmdns.c
+++ b/esp32/mods/modmdns.c
@@ -168,6 +168,7 @@ STATIC mp_obj_t mod_mdns_add_service(mp_uint_t n_args, const mp_obj_t *pos_args,
             mp_obj_t* items;
             mp_obj_tuple_get(args[3].u_obj, &length_total, &items);
 
+            // FIXME: This should be reviewed. "m_malloc" might not be appropriate here.
             service_txt = m_malloc(length_total * sizeof(mdns_txt_item_t));
 
             for(int i = 0; i < length_total; i++) {

--- a/esp32/mods/modpycom.c
+++ b/esp32/mods/modpycom.c
@@ -302,16 +302,15 @@ STATIC mp_obj_t mod_pycom_nvs_get (mp_uint_t n_args, const mp_obj_t *args) {
     else {
         esp_err = nvs_get_str(pycom_nvs_handle, key, NULL, &value);
         if(esp_err == ESP_OK) {
-            char* value_string = (char*)m_malloc(value);
+            char* value_string = (char*)pvPortMalloc(value);
 
             esp_err = nvs_get_str(pycom_nvs_handle, key, value_string, &value);
 
             if(esp_err == ESP_OK) {
                 //do not count the terminating \0
                 ret = mp_obj_new_str(value_string, value-1);
-                m_free(value_string);
             }
-            m_free(value_string);
+            vPortFree(value_string);
         }
     }
 
@@ -422,7 +421,7 @@ STATIC mp_obj_t mod_pycom_wifi_ssid_sta (mp_uint_t n_args, const mp_obj_t *args)
         else{/*Nothing*/}
 
     } else {
-        uint8_t * ssid = (uint8_t *)m_malloc(33);
+        uint8_t * ssid = (uint8_t *)pvPortMalloc(33);
         mp_obj_t ssid_obj;
         if(config_get_wifi_sta_ssid(ssid))
         {
@@ -432,7 +431,7 @@ STATIC mp_obj_t mod_pycom_wifi_ssid_sta (mp_uint_t n_args, const mp_obj_t *args)
         {
             ssid_obj = mp_const_none;
         }
-        m_free(ssid);
+        vPortFree(ssid);
         return ssid_obj;
     }
     return mp_const_none;
@@ -451,7 +450,7 @@ STATIC mp_obj_t mod_pycom_wifi_pwd_sta (mp_uint_t n_args, const mp_obj_t *args) 
         }
         else{/*Nothing*/}
     } else {
-        uint8_t * pwd = (uint8_t *)m_malloc(65);
+        uint8_t * pwd = (uint8_t *)pvPortMalloc(65);
         mp_obj_t pwd_obj;
         if(config_get_wifi_sta_pwd(pwd))
         {
@@ -461,7 +460,7 @@ STATIC mp_obj_t mod_pycom_wifi_pwd_sta (mp_uint_t n_args, const mp_obj_t *args) 
         {
             pwd_obj = mp_const_none;
         }
-        m_free(pwd);
+        vPortFree(pwd);
         return pwd_obj;
     }
     return mp_const_none;
@@ -480,7 +479,7 @@ STATIC mp_obj_t mod_pycom_wifi_ssid_ap (mp_uint_t n_args, const mp_obj_t *args) 
         }
         else{/*Nothing*/}
     } else {
-        uint8_t * ssid = (uint8_t *)m_malloc(33);
+        uint8_t * ssid = (uint8_t *)pvPortMalloc(33);
         mp_obj_t ssid_obj;
         if(config_get_wifi_ap_ssid(ssid))
         {
@@ -490,7 +489,7 @@ STATIC mp_obj_t mod_pycom_wifi_ssid_ap (mp_uint_t n_args, const mp_obj_t *args) 
         {
             ssid_obj = mp_const_none;
         }
-        m_free(ssid);
+        vPortFree(ssid);
         return ssid_obj;
     }
     return mp_const_none;
@@ -509,7 +508,7 @@ STATIC mp_obj_t mod_pycom_wifi_pwd_ap (mp_uint_t n_args, const mp_obj_t *args) {
         }
         else{/*Nothing*/}
     } else {
-        uint8_t * pwd = (uint8_t *)m_malloc(65);
+        uint8_t * pwd = (uint8_t *)pvPortMalloc(65);
         mp_obj_t pwd_obj;
         if(config_get_wifi_ap_pwd(pwd))
         {
@@ -519,7 +518,7 @@ STATIC mp_obj_t mod_pycom_wifi_pwd_ap (mp_uint_t n_args, const mp_obj_t *args) {
         {
             pwd_obj = mp_const_none;
         }
-        m_free(pwd);
+        vPortFree(pwd);
         return pwd_obj;
     }
     return mp_const_none;

--- a/esp32/mods/moducrypto.c
+++ b/esp32/mods/moducrypto.c
@@ -324,7 +324,7 @@ STATIC mp_obj_t mod_crypt_generate_rsa_signature(mp_uint_t n_args, const mp_obj_
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_RuntimeError, "Message Digest operation failed, error code: %d", rc));
     }
 
-    unsigned char *signature = m_malloc(5000);
+    unsigned char *signature = pvPortMalloc(5000);
     size_t signature_length;
 
     rc = mbedtls_pk_sign(&pk_context, MBEDTLS_MD_SHA256, digest, sizeof(digest), signature, &signature_length, mbedtls_ctr_drbg_random, &ctr_drbg);
@@ -335,7 +335,7 @@ STATIC mp_obj_t mod_crypt_generate_rsa_signature(mp_uint_t n_args, const mp_obj_
     mp_obj_t ret_signature = mp_obj_new_bytes((const byte*)signature, signature_length);
 
     mbedtls_pk_free(&pk_context);
-    m_free((char*)signature);
+    vPortFree((char*)signature);
 
     return ret_signature;
 }
@@ -382,7 +382,7 @@ STATIC mp_obj_t mod_crypt_rsa_encrypt(mp_uint_t n_args, const mp_obj_t *pos_args
         strlen(pers));
 
     size_t output_len = message.len + 256;
-    unsigned char *output = m_malloc(output_len);
+    unsigned char *output = pvPortMalloc(output_len);
     size_t output_actual_length = 0;
 
     rc = mbedtls_pk_encrypt(&pk_context,
@@ -401,7 +401,7 @@ STATIC mp_obj_t mod_crypt_rsa_encrypt(mp_uint_t n_args, const mp_obj_t *pos_args
     mp_obj_t ret_output = mp_obj_new_bytes((const byte*)output, output_actual_length);
 
     mbedtls_pk_free(&pk_context);
-    m_free((char*)output);
+    vPortFree((char*)output);
 
     return ret_output;
 }
@@ -448,7 +448,7 @@ STATIC mp_obj_t mod_crypt_rsa_decrypt(mp_uint_t n_args, const mp_obj_t *pos_args
         strlen(pers));
 
     size_t output_len = message.len + 256;
-    unsigned char *output = m_malloc(output_len);
+    unsigned char *output = pvPortMalloc(output_len);
     size_t output_actual_length = 0;
 
     rc = mbedtls_pk_decrypt(&pk_context,
@@ -467,7 +467,7 @@ STATIC mp_obj_t mod_crypt_rsa_decrypt(mp_uint_t n_args, const mp_obj_t *pos_args
     mp_obj_t ret_output = mp_obj_new_bytes((const byte*)output, output_actual_length);
 
     mbedtls_pk_free(&pk_context);
-    m_free((char*)output);
+    vPortFree((char*)output);
 
     return ret_output;
 }

--- a/esp32/mptask.c
+++ b/esp32/mptask.c
@@ -534,7 +534,7 @@ STATIC void mptask_init_sflash_filesystem_littlefs(void) {
     MP_STATE_PORT(vfs_cur) = vfs;
 
     //Initialize the current working directory (cwd)
-    vfs_littlefs->fs.littlefs.cwd = (char*)m_malloc(2);
+    vfs_littlefs->fs.littlefs.cwd = (char*)pvPortMalloc(2);
     vfs_littlefs->fs.littlefs.cwd[0] = '/';
     vfs_littlefs->fs.littlefs.cwd[1] = '\0';
 

--- a/esp32/mpthreadport.c
+++ b/esp32/mpthreadport.c
@@ -280,6 +280,7 @@ void vPortCleanUpTCB (void *tcb) {
 
 mp_obj_thread_lock_t *mp_thread_new_thread_lock(void) {
     mp_obj_thread_lock_t *self = m_new_obj(mp_obj_thread_lock_t);
+    // FIXME: This should be reviewed. "gc_alloc" might not be appropriate here.
     self->mutex = gc_alloc(sizeof(mp_thread_mutex_t), false);
     if (NULL == self->mutex) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_MemoryError, "can't create lock"));


### PR DESCRIPTION
Dear Pycom team,

we investigated some random core panics we have been observing when working on our [Terkin datalogger](https://github.com/hiveeyes/terkin-datalogger) based on the FiPy. More details about this can be found within [1].

We will be happy if you could review this change. While we are not 100% sure we did the changes in the right manner, we are pretty much confident it improves accessing the filesystem at runtime through the FTP server and the LittleFS filesystem. We already verified this on our own devices and with other members of the community.

With kind regards,
Andreas.

[1] https://community.hiveeyes.org/t/dont-invoke-micropythons-m-malloc-within-c-level-rtos-extensions/2743
