### PR TITLE
telnet/telnet.c: Fix handling of special Ctrl-Characters

### DIFF
--- a/esp32/mptask.c
+++ b/esp32/mptask.c
@@ -48,6 +48,7 @@
 #include "modled.h"
 #include "esp_log.h"
 #include "mods/pybflash.h"
+#include "telnet/telnet.h"
 
 #if defined (LOPY) || defined (LOPY4) || defined (FIPY)
 #include "modlora.h"
@@ -357,6 +358,7 @@ soft_reset_exit:
     ets_delay_us(5000);
 
     uart_deinit_all();
+    telnet_reset();
     // TODO: rmt_deinit_all();
     rmt_deinit_rgb();
 

--- a/esp32/telnet/telnet.c
+++ b/esp32/telnet/telnet.c
@@ -533,14 +533,11 @@ static void telnet_parse_input (uint8_t *str, int32_t *len) {
 
         // in this case the server is not operating in binary mode
         if (ch > 127 || ch == 0 || (telnet_data.state == E_TELNET_STE_LOGGED_IN &&
-            (ch == mp_interrupt_char || ch == CHAR_CTRL_F))) {
+            (ch == mp_interrupt_char || ch == mp_reset_char))) {
             if (ch == mp_interrupt_char) {
                 mp_keyboard_interrupt();
-            } else if (ch == CHAR_CTRL_F) {
-                *str++ = CHAR_CTRL_D;
-                mp_hal_reset_safe_and_boot(false);
-                _str++;
-                continue;
+            } else if (ch == mp_reset_char) {
+                mp_hal_reset_safe_and_boot(true);
             }
             // skip this char
             (*len)--;


### PR DESCRIPTION
Telnet will now like calls to sys.stdin.read() consider the
setting for interrupt characters as requested by calling
the micropython.kbd_intr() call.
Ctrl-F, if active, will now perform a reboot into safe mode,
        and will be ignored if set so.
Ctrl-D at the start of a line will cause a soft reboot, albeit
       closing the telnet session.
Ctrl_C will still be checked in commands which use mp_readline(), like
the input() statement. Test script for this PR:

```
from micropython import kbd_intr
import sys

def getline(prompt):
    l = ""
    print(prompt, end="")
    while True:
        c = sys.stdin.read(1)
        if c == '\n' or c == '\r':
            print()
            break
        else:
            sys.stdout.write(c)
            l += c
    return l

def run(msg):
    print(msg)
    while True:
        try:
            l = getline("get a line: ")
            if l == "q":
                break
        except KeyboardInterrupt:
            print("Interrupted by Ctrl-C")
            break

kbd_intr(-1)
run("Full disabled")

kbd_intr(3, -1)
run("Ctrl-F disabled")

kbd_intr(-1, 6)
run("Ctrl-C disabled")
```