### PR TITLE
sx1276-board.c, sx1276.h: Fix crash on calling lora.reset()

### DIFF
--- a/drivers/sx127x/sx1276/sx1276.h
+++ b/drivers/sx127x/sx1276/sx1276.h
@@ -407,4 +407,9 @@ void SX1276SetMaxPayloadLength( RadioModems_t modem, uint8_t max );
  */
 void SX1276SetPublicNetwork( bool enable );
 
+/*!
+ * \brief Resets the SX1276
+ */
+void SX1276Reset( void );
+
 #endif // __SX1276_H__

--- a/esp32/lora/sx1276-board.c
+++ b/esp32/lora/sx1276-board.c
@@ -50,7 +50,8 @@ DRAM_ATTR const struct Radio_s Radio =
     SX1276WriteBuffer,
     SX1276ReadBuffer,
     SX1276SetMaxPayloadLength,
-    SX1276SetPublicNetwork
+    SX1276SetPublicNetwork,
+    SX1276Reset
 };
 
 /*!


### PR DESCRIPTION
The crash is caused by an uninitialized entry in a call address table. Thus, using the method lora.reset() causes a call to address 0, which in turn results in a crash and core dump.
Fixes issue https://github.com/pycom/pycom-micropython-sigfox/issues/425
Edit: It seems that lora.reset() is a NOP on all rev1 boards, which include LoPy4. It seems only do something on a LoPy1, which uses the SX1272 chip, and the fix here is for the SX1276 drivers. Still the crash shall be fixed, or the method has to be removed from the module.