### PR TITLE
Remove wake-on-boot argument parsing causing errors

### DIFF
--- a/esp32/tools/fw_updater/README.md
+++ b/esp32/tools/fw_updater/README.md
@@ -1,0 +1,40 @@
+# Pycom firmware updater
+Script for updating firmaware on Pycom modules
+
+## Download firmware
+Links for Pygate firmware for the available modules (WiPy, GPy, and LoPy4) can be found [here](https://docs.pycom.io/advance/downgrade/).
+
+# Quickstart
+Install and activate a `virtualenv`
+```
+python3.7 -m venv venv
+source venv/bin/activate
+```
+
+Install dependencies
+```
+pip install -r requirements
+deactivate
+```
+
+As root user, activate `venv` and run updater
+```
+sudo su
+source venv/bin/activate
+./updater.py -v -p /dev/ttyACM1 flash -t ~/path/to/firmware/LoPy4-1.20.2.rc11.tar.gz
+```
+
+Set WiFi Access point SSID and password
+```
+./updater.py -v -p /dev/ttyACM1 wifi --ssid <ssid name> --pwd <password>
+```
+
+Set LoRa Region
+```
+./updater.py -v -p /dev/ttyACM1 lpwan --region <'EU868', 'US915', 'AS923', 'AU915', or 'IN865'>
+```
+
+Set filesystem type
+```
+./updater.py -v -p /dev/ttyACM1 pycom --fs_type <'FatFS' or 'LittleFS'>
+```

--- a/esp32/tools/fw_updater/requirements.txt
+++ b/esp32/tools/fw_updater/requirements.txt
@@ -1,0 +1,1 @@
+pyserial


### PR DESCRIPTION
# Problem
I could not set the WIFI ssid or password after flashing the firmware on my LoPy4, as the updater script would fail when it attempted to handle an argument that was commented out.

# Solution
* Remove handling of `wob` argument that caused errors in script.
* Add a a `pip` requirements file to specify the requirement on `pyserial`
* Add a brief README to assist others with script usage