### PR TITLE
modled.c, mperror.c: Ensure 280µs reset time for the RGB LED

### DIFF
--- a/esp32/mods/modled.c
+++ b/esp32/mods/modled.c
@@ -23,7 +23,7 @@
 #define LED_BIT_1_LOW_PERIOD  (3) // 300ns
 #define LED_BIT_0_HIGH_PERIOD (3) // 300ns
 #define LED_BIT_0_LOW_PERIOD  (9) // 900ns
-#define LED_RESET_PERIOD      (1500) // at least 150us
+#define LED_RESET_PERIOD      (2800) // at least 280us
 
 /******************************************************************************
  DECLARE PRIVATE FUNCTIONS

--- a/esp32/util/mperror.c
+++ b/esp32/util/mperror.c
@@ -54,7 +54,7 @@
 #ifndef BOOTLOADER_BUILD
 STATIC const mp_obj_base_t pyb_heartbeat_obj = {&pyb_heartbeat_type};
 
-static rmt_item32_t rmt_grb_items[COLOR_BITS];
+static rmt_item32_t rmt_grb_items[COLOR_BITS + 1];
 
 led_info_t led_info = {
     .rmt_channel = RMT_CHANNEL_1,


### PR DESCRIPTION
Otherwise, if two consecutive calls to pycom.rgbled() are called,
the second one may not get effective.