### PR TITLE
LTE: fix conditional in lte_check_attached

### DIFF
--- a/esp32/mods/modlte.c
+++ b/esp32/mods/modlte.c
@@ -280,8 +280,7 @@ static bool lte_check_attached(bool legacy) {
                     mp_hal_delay_ms(LTE_RX_TIMEOUT_MIN_MS);
                     lte_push_at_command("AT+CEREG?", LTE_RX_TIMEOUT_MIN_MS);
                 }
-                if (((pos = strstr(modlte_rsp.data, "+CEREG: 1,1")) || (pos = strstr(modlte_rsp.data, "+CEREG: 1,5")))
-                        && (strlen(pos) >= 31) && (pos[30] == '7' || pos[30] == '9')) {
+                if ((pos = strstr(modlte_rsp.data, "+CEREG: 1,1")) || (pos = strstr(modlte_rsp.data, "+CEREG: 1,5"))) {
                     attached = true;
                 }
             } else {


### PR DESCRIPTION
As `CEREG` was set to `1` in this [commit](https://github.com/pycom/pycom-micropython-sigfox/pull/499/commits/8e631efefb6b3d7be6731f826c06dcaf85231785) the answer to an `"AT+CEREG?"` will only contain information up to the  `<stat>`-value. So `lte_check_attached` with `legacy=true` and when `"AT+CGATT?"` returns `0` will always return false.

This tiny PR should fix the problem.