### PR TITLE
vfs_littlefs_file.c: Prevent double close of a file

### DIFF
--- a/esp32/littlefs/vfs_littlefs_file.c
+++ b/esp32/littlefs/vfs_littlefs_file.c
@@ -108,11 +108,11 @@ STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
             int res = littlefs_close_common_helper(&self->littlefs->lfs, &self->fp, &self->cfg, &self->timestamp_update);
         xSemaphoreGive(self->littlefs->mutex);
 
-        self->littlefs = NULL; // indicate a closed file
         if (res < 0) {
             *errcode = littleFsErrorToErrno(res);
             return MP_STREAM_ERROR;
         }
+        self->littlefs = NULL; // indicate a closed file
         return 0;
     } else {
         *errcode = MP_EINVAL;


### PR DESCRIPTION
An attempt to close a file twice resulted in a crash, because buffers
should have been freed again. This change checks first, if a file is
already closed.