### PR TITLE
Fix Pygate LoRa rx lock-up after LoRa tx

### DIFF
--- a/esp32/pygate/concentrator/cmd_manager.c
+++ b/esp32/pygate/concentrator/cmd_manager.c
@@ -324,7 +324,7 @@ int cmd_manager_DecodeCmd(uint8_t *BufFromHost) {
                 }
 
                 /* Switch off SX1308 correlators to reduce power consumption during transmit */
-                esp_lgw_reg_w(LGW_CLKHS_EN, 0);
+                //esp_lgw_reg_w(LGW_CLKHS_EN, 0);
 
                 /* Send packet */
                 SX1308.txongoing = 1;
@@ -359,16 +359,16 @@ int cmd_manager_DecodeCmd(uint8_t *BufFromHost) {
                 }
 
                 /* reset Sx1308 */
-                sx1308_dig_reset();
+                //sx1308_dig_reset();
 
                 /* Switch SX1308 correlators back on  */
-                esp_lgw_reg_w(LGW_CLKHS_EN, 1);
+                //esp_lgw_reg_w(LGW_CLKHS_EN, 1);
 
                 /* restart SX1308 */
-                x = esp_lgw_start();
-                if (x < 0) {
+                //x = esp_lgw_start();
+                //if (x < 0) {
                     //pc.printf("lgw_start() failed\n");
-                }
+                //}
 
                 /* Send command answer */
                 BufToHost[0] = 'f';


### PR DESCRIPTION
Hi Pycom team,

This issue was discussed at https://forum.pycom.io/topic/7042/pygate-does-not-receive-after-downlink?_=1624679301959.

**The Issue**
I experienced a Pygate firmware issue that Pygate will not receive LoRa message after a downlink message is sent. This issue is not related to LTE-M, but on LoRa gateway side. Power cycle the Pygate will fix this problem.

**The Fix**
I spent quite bit of time to try to fix.
I am not quite understand that part of the code, but I managed to fix it. Basically, disable gateway reset/restart after tx.
Now, the Pygate continues to rx after tx. There is no more lock up. I will continue testing the long term, but so far so good.

**My Hardware**
- PyGate 915
- GPY
- LTE-M1 network with public ipv4 address
- chirpstack-gateway-bridge 3.11.0 at AWS to receive udp from Pygate

**My Compile Environment**
- Ubuntu 20.04 VM
- https://github.com/pycom/pycom-micropython-sigfox v1.20.2.r4 code base Dev branch a37510c092bcec00671c924accb97dcdfa2f4b5d